### PR TITLE
walker consent command comma missing

### DIFF
--- a/website/docs/clients/walkerjs/commands.mdx
+++ b/website/docs/clients/walkerjs/commands.mdx
@@ -99,7 +99,7 @@ it's treated as consent being granted. Previously pushed events during the run
 are shared now with destinations as well as new ones.
 
 ```js
-elb("walker consent" { marketing: true, randomTool: true });
+elb("walker consent", { marketing: true, randomTool: true });
 ```
 
 Setting a consent state to `false` will immediately stop a destination from


### PR DESCRIPTION
I noticed that the comma was missing in the documentation of the walker consent command.