### PR TITLE
batch with wildcard mapping

### DIFF
--- a/packages/core/src/types/destination.ts
+++ b/packages/core/src/types/destination.ts
@@ -60,6 +60,7 @@ export interface Instance<T extends TypesGeneric = Types> {
   config: Config<T>;
   queue?: WalkerOS.Events;
   dlq?: DLQ;
+  batches?: BatchRegistry<Mapping<T>>;
   type?: string;
   env?: Env<T>;
   init?: InitFn<T>;
@@ -126,13 +127,15 @@ export interface InitContext<T extends TypesGeneric = Types> {
   logger: Logger.Instance;
 }
 
-export interface PushContext<T extends TypesGeneric = Types>
-  extends Context<T> {
+export interface PushContext<
+  T extends TypesGeneric = Types,
+> extends Context<T> {
   mapping?: WalkerOSMapping.Rule<Mapping<T>>;
 }
 
-export interface PushBatchContext<T extends TypesGeneric = Types>
-  extends Context<T> {
+export interface PushBatchContext<
+  T extends TypesGeneric = Types,
+> extends Context<T> {
   mapping?: WalkerOSMapping.Rule<Mapping<T>>;
 }
 
@@ -161,6 +164,13 @@ export interface Batch<Mapping> {
   events: WalkerOS.Events;
   data: Array<Data>;
   mapping?: WalkerOSMapping.Rule<Mapping>;
+}
+
+export interface BatchRegistry<Mapping> {
+  [mappingKey: string]: {
+    batched: Batch<Mapping>;
+    batchFn: () => void;
+  };
 }
 
 export type Data =


### PR DESCRIPTION
The problem was when API destination used batch config with wildcards (`"*": {"*": { batch: 500 }}`), events were sent to only one destination (or duplicated) because batch state was stored on the shared mapping Rule object.

The shared object reference caused the bug. Multiple destinations sharing the same mapping config would share the same `batched` array and `batchFn`, causing only the last destination to receive events.

We added a `BatchRegistry` type, which is now stored in `destination.batches[mappingKey]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for debounce-based batching with wildcard mapping configurations, covering event deduplication, per-key batch separation, and cross-destination isolation scenarios.

* **Refactor**
  * Restructured batching architecture to use destination-level state instead of mapping-level state, improving isolation and preventing potential duplicates or misrouting when configurations are shared across destinations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->