### PR TITLE
win backslashes

### DIFF
--- a/.changeset/fix-windows-bundle-paths.md
+++ b/.changeset/fix-windows-bundle-paths.md
@@ -1,0 +1,6 @@
+---
+'@walkeros/cli': patch
+---
+
+Fix `walkeros bundle` failing on Windows when stage 2 import paths contained
+backslashes that JS parsed as escape sequences.

--- a/packages/cli/src/commands/bundle/__tests__/bundler.test.ts
+++ b/packages/cli/src/commands/bundle/__tests__/bundler.test.ts
@@ -3,6 +3,10 @@ import {
   validateComponentNames,
   collectAllStepPackages,
   buildSplitConfigObject,
+  generateServerEntry,
+  generateWebEntry,
+  generateWrapEntry,
+  generateWrapEntryServer,
 } from '../bundler';
 import type { Flow } from '@walkeros/core';
 
@@ -337,4 +341,28 @@ describe('path-based package: normalization', () => {
     const result = collectAllStepPackages(flowSettings);
     expect(result.has('./packages/server/sources/express')).toBe(true);
   });
+});
+
+describe('stage 2 entry path normalization (issue #636)', () => {
+  const winPath = ['C:', 'tmp', 'cache', 'code', 'abc.mjs'].join(
+    String.fromCharCode(92),
+  );
+  const cases = [
+    {
+      name: 'generateServerEntry',
+      emit: () => generateServerEntry(winPath, '{}'),
+    },
+    { name: 'generateWebEntry', emit: () => generateWebEntry(winPath, '{}') },
+    { name: 'generateWrapEntry', emit: () => generateWrapEntry(winPath) },
+    {
+      name: 'generateWrapEntryServer',
+      emit: () => generateWrapEntryServer(winPath),
+    },
+  ];
+
+  for (const { name, emit } of cases) {
+    it(`${name} emits no backslashes in the import specifier`, () => {
+      expect(emit()).toContain("from 'C:/tmp/cache/code/abc.mjs'");
+    });
+  }
 });

--- a/packages/cli/src/commands/bundle/bundler.ts
+++ b/packages/cli/src/commands/bundle/bundler.ts
@@ -150,6 +150,7 @@ import type { BuildOptions } from '../../types/bundle.js';
 import { downloadPackages } from './package-manager.js';
 import type { Logger } from '@walkeros/core';
 import { getTmpPath } from '../../core/tmp.js';
+import { toFileImportSpecifier } from '../../core/import-specifier.js';
 import {
   isBuildCached,
   getCachedBuild,
@@ -1417,7 +1418,8 @@ export function generateServerEntry(
   stage1Path: string,
   dataPayload: string,
 ): string {
-  return `import { startFlow, wireConfig } from '${stage1Path}';
+  const stage1Specifier = toFileImportSpecifier(stage1Path);
+  return `import { startFlow, wireConfig } from '${stage1Specifier}';
 
 const __configData = ${dataPayload};
 
@@ -1487,7 +1489,8 @@ export function generateWebEntry(
   }`
       : '';
 
-  return `import { startFlow, wireConfig } from '${stage1Path}';
+  const stage1Specifier = toFileImportSpecifier(stage1Path);
+  return `import { startFlow, wireConfig } from '${stage1Specifier}';
 
 const __configData = ${dataPayload};
 
@@ -1604,7 +1607,8 @@ export function generateWrapEntry(
   }`
       : '';
 
-  return `import { startFlow, wireConfig, __configData } from '${stage1Path}';
+  const stage1Specifier = toFileImportSpecifier(stage1Path);
+  return `import { startFlow, wireConfig, __configData } from '${stage1Specifier}';
 
 (async () => {${preflightBlock}
   const config = wireConfig(__configData);${envBlock}
@@ -1622,7 +1626,8 @@ export function generateWrapEntry(
  * `{ collector, elb, httpHandler? }`.
  */
 export function generateWrapEntryServer(stage1Path: string): string {
-  return `import { startFlow, wireConfig, __configData } from '${stage1Path}';
+  const stage1Specifier = toFileImportSpecifier(stage1Path);
+  return `import { startFlow, wireConfig, __configData } from '${stage1Specifier}';
 
 export default async function(context = {}) {
   const config = wireConfig(__configData);

--- a/packages/cli/src/commands/push/flow-context.ts
+++ b/packages/cli/src/commands/push/flow-context.ts
@@ -126,7 +126,9 @@ export async function withFlowContext(
       }
     }
 
-    // Import ESM bundle with cache bust
+    // Import ESM bundle with cache bust. Node runtime import() accepts
+    // file:// URLs; for paths embedded into source for esbuild bundling
+    // use core/import-specifier.ts instead (esbuild rejects file://).
     const fileUrl = pathToFileURL(path.resolve(esmPath)).href;
     const module = await import(`${fileUrl}?t=${Date.now()}`);
     const { wireConfig, startFlow } = module;

--- a/packages/cli/src/core/import-specifier.ts
+++ b/packages/cli/src/core/import-specifier.ts
@@ -1,0 +1,10 @@
+/**
+ * Normalise an absolute path for embedding into generated import statements
+ * that esbuild will bundle. Backslashes become escape sequences when JS
+ * parses the import (e.g. \5 turns into U+0005), so we always emit forward
+ * slashes — esbuild and Node both resolve them on every platform, Windows
+ * included. For Node runtime import() use pathToFileURL(...).href instead;
+ * esbuild's static resolver does not accept file:// URLs.
+ */
+export const toFileImportSpecifier = (absPath: string): string =>
+  absPath.replace(/\\/g, '/');

--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -18,3 +18,4 @@ export { parseSSEEvents } from './sse.js';
 export type { SSEEvent, SSEParseResult } from './sse.js';
 export * from './event-validation.js';
 export * from './package-path.js';
+export * from './import-specifier.js';

--- a/packages/cli/src/runtime/load-bundle.ts
+++ b/packages/cli/src/runtime/load-bundle.ts
@@ -44,6 +44,9 @@ export async function loadBundle(
   logger?: Logger.Instance,
 ): Promise<BundleResult> {
   const absolutePath = resolve(file);
+  // Node's runtime import() accepts file:// URLs per ESM spec. This is
+  // distinct from paths emitted into source for esbuild bundling — for
+  // that, use core/import-specifier.ts (esbuild does not resolve file://).
   const fileUrl = pathToFileURL(absolutePath).href;
 
   // Bust Node.js module cache by appending a query param


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed `walkeros bundle` command failing on Windows when import paths contained backslashes that were misinterpreted as escape sequences. Paths are now properly normalized in generated import statements.

## Tests
* Added test suite verifying path normalization across entry generators to ensure backslashes are converted to forward slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->