### PR TITLE
Added d8a.tech web destination

### DIFF
--- a/.changeset/d8a-web-destination.md
+++ b/.changeset/d8a-web-destination.md
@@ -1,0 +1,6 @@
+---
+'@walkeros/web-destination-d8a': patch
+---
+
+Add the d8a.tech web destination for a GA4-compatible and warehouse-native
+analytics platform.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5188,6 +5188,12 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/@d8a-tech/wt": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@d8a-tech/wt/-/wt-1.2.1.tgz",
+      "integrity": "sha512-AMWjtt6ikJVHS5n535e5gA4Jp4Wcu83XXOlNNN96c3X3HfMGqS7v9inAZ+tnLUuFp4L1IEs4T0sbU0jBmaH7xQ==",
+      "license": "MIT"
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "license": "MIT",
@@ -15758,6 +15764,10 @@
     },
     "node_modules/@walkeros/web-destination-clarity": {
       "resolved": "packages/web/destinations/clarity",
+      "link": true
+    },
+    "node_modules/@walkeros/web-destination-d8a": {
+      "resolved": "packages/web/destinations/d8a",
       "link": true
     },
     "node_modules/@walkeros/web-destination-fullstory": {
@@ -40720,6 +40730,25 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/clarity": "^1.0.2",
+        "@walkeros/core": "4.0.2",
+        "@walkeros/web-core": "4.0.2"
+      },
+      "devDependencies": {
+        "@walkeros/collector": "4.0.2"
+      }
+    },
+    "packages/web/destinations/d8a": {
+      "name": "@walkeros/web-destination-d8a",
+      "version": "4.0.2",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/elbwalker"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@d8a-tech/wt": "^1.2.1",
         "@walkeros/core": "4.0.2",
         "@walkeros/web-core": "4.0.2"
       },

--- a/packages/web/destinations/d8a/README.md
+++ b/packages/web/destinations/d8a/README.md
@@ -1,0 +1,124 @@
+# @walkeros/web-destination-d8a
+
+d8a web destination for walkerOS. It sends walkerOS events to the d8a web
+tracker using the GA4 gtag-style `d8a()` API.
+
+[Source Code](https://github.com/elbwalker/walkerOS/tree/main/packages/web/destinations/d8a)
+&bull;
+[NPM Package](https://www.npmjs.com/package/@walkeros/web-destination-d8a)
+
+## Installation
+
+```bash
+npm install @walkeros/web-destination-d8a
+```
+
+## Usage
+
+```typescript
+import { startFlow } from '@walkeros/collector';
+import { destinationD8a } from '@walkeros/web-destination-d8a';
+
+await startFlow({
+  destinations: {
+    d8a: {
+      code: destinationD8a,
+      config: {
+        settings: {
+          property_id: '80e1d6d0-560d-419f-ac2a-fe9281e93386',
+          server_container_url:
+            'https://global.t.d8a.tech/80e1d6d0-560d-419f-ac2a-fe9281e93386/d/c',
+        },
+      },
+    },
+  },
+});
+```
+
+## Configuration
+
+| Name                   | Type                | Required | Description                                 |
+| ---------------------- | ------------------- | -------- | ------------------------------------------- |
+| `property_id`          | `string`            | Yes      | d8a property ID                             |
+| `server_container_url` | `string`            | Yes      | d8a collector URL for the property          |
+| `send_page_view`       | `boolean`           | No       | Set `false` to disable automatic page views |
+| `debug_mode`           | `boolean`           | No       | Enable d8a debug mode                       |
+| `dataLayerName`        | `string`            | No       | Queue name, defaults to `d8aLayer`          |
+| `globalName`           | `string`            | No       | Global function name, defaults to `d8a`     |
+| `snakeCase`            | `boolean`           | No       | Convert walkerOS event names to snake_case  |
+| `como`                 | `boolean \| object` | No       | Consent mode mapping, defaults to `true`    |
+
+The destination follows d8a behavior for page views: automatic page views are
+preserved by default and disabled only when `send_page_view: false` is
+configured.
+
+## Event Mapping
+
+By default, walkerOS event names are converted to snake_case and sent with the
+configured property ID as `send_to`.
+
+```typescript
+mapping: {
+  order: {
+    complete: {
+      name: 'purchase',
+      data: {
+        map: {
+          transaction_id: 'data.id',
+          value: 'data.total',
+          currency: { key: 'data.currency', value: 'EUR' },
+        },
+      },
+    },
+  },
+}
+```
+
+This produces:
+
+```typescript
+d8a('event', 'purchase', {
+  transaction_id: '0rd3r1d',
+  value: 555,
+  currency: 'EUR',
+  send_to: '80e1d6d0-560d-419f-ac2a-fe9281e93386',
+});
+```
+
+## Consent Mode
+
+The destination supports d8a's gtag-compatible consent mode. By default, the
+mapping is:
+
+| walkerOS consent key | d8a consent fields                                 |
+| -------------------- | -------------------------------------------------- |
+| `marketing`          | `ad_storage`, `ad_user_data`, `ad_personalization` |
+| `functional`         | `analytics_storage`                                |
+
+Disable consent mode with:
+
+```typescript
+settings: {
+  como: false,
+}
+```
+
+Or provide a custom mapping:
+
+```typescript
+settings: {
+  como: {
+    analytics: 'analytics_storage',
+    marketing: ['ad_storage', 'ad_personalization'],
+  },
+}
+```
+
+## Related
+
+- [d8a web tracker docs](https://docs.d8a.tech/articles/sources/web-tracker/)
+- [Destination interface](../../../core/src/types/destination.ts)
+
+## License
+
+MIT

--- a/packages/web/destinations/d8a/jest.config.mjs
+++ b/packages/web/destinations/d8a/jest.config.mjs
@@ -1,0 +1,5 @@
+import baseConfig from '@walkeros/config/jest/web.config';
+
+const config = {};
+
+export default { ...baseConfig, ...config };

--- a/packages/web/destinations/d8a/package.json
+++ b/packages/web/destinations/d8a/package.json
@@ -66,8 +66,7 @@
     "destination",
     "web",
     "d8a",
-    "analytics",
-    "gtag"
+    "analytics"
   ],
   "funding": [
     {

--- a/packages/web/destinations/d8a/package.json
+++ b/packages/web/destinations/d8a/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@walkeros/web-destination-d8a",
+  "description": "d8a web destination for walkerOS",
+  "version": "4.0.2",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./examples": {
+      "types": "./dist/examples/index.d.ts",
+      "import": "./dist/examples/index.mjs",
+      "require": "./dist/examples/index.js"
+    },
+    "./dev": {
+      "types": "./dist/dev.d.ts",
+      "import": "./dist/dev.mjs",
+      "require": "./dist/dev.js"
+    },
+    "./walkerOS.json": "./dist/walkerOS.json"
+  },
+  "files": [
+    "dist/**"
+  ],
+  "scripts": {
+    "build": "tsup --silent",
+    "clean": "rm -rf .turbo && rm -rf dist",
+    "dev": "jest --watchAll --colors",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint \"**/*.ts*\"",
+    "test": "jest",
+    "update": "npx npm-check-updates -u && npm update"
+  },
+  "dependencies": {
+    "@d8a-tech/wt": "^1.2.1",
+    "@walkeros/core": "4.0.2",
+    "@walkeros/web-core": "4.0.2"
+  },
+  "devDependencies": {
+    "@walkeros/collector": "4.0.2"
+  },
+  "repository": {
+    "url": "git+https://github.com/elbwalker/walkerOS.git",
+    "directory": "packages/web/destinations/d8a"
+  },
+  "author": "elbwalker <hello@elbwalker.com>",
+  "homepage": "https://github.com/elbwalker/walkerOS#readme",
+  "bugs": {
+    "url": "https://github.com/elbwalker/walkerOS/issues"
+  },
+  "walkerOS": {
+    "type": "destination",
+    "platform": [
+      "web"
+    ],
+    "docs": "https://www.walkeros.io/docs/destinations/web/d8a"
+  },
+  "keywords": [
+    "walkerOS",
+    "walkerOS-destination",
+    "destination",
+    "web",
+    "d8a",
+    "analytics",
+    "gtag"
+  ],
+  "funding": [
+    {
+      "type": "GitHub Sponsors",
+      "url": "https://github.com/sponsors/elbwalker"
+    }
+  ]
+}

--- a/packages/web/destinations/d8a/src/dev.ts
+++ b/packages/web/destinations/d8a/src/dev.ts
@@ -1,0 +1,2 @@
+export * as schemas from './schemas';
+export * as examples from './examples';

--- a/packages/web/destinations/d8a/src/examples/env.ts
+++ b/packages/web/destinations/d8a/src/examples/env.ts
@@ -1,0 +1,56 @@
+import type { D8aFn, InstallD8aOptions, InstallD8aResult } from '@d8a-tech/wt';
+import type { Env } from '../types';
+
+function createD8a(): D8aFn {
+  const d8a = (() => {}) as D8aFn;
+  d8a.js = () => {};
+  d8a.config = () => {};
+  d8a.event = () => {};
+  d8a.set = () => {};
+  d8a.consent = () => {};
+  return d8a;
+}
+
+const installD8a = (opts?: InstallD8aOptions): InstallD8aResult => {
+  const windowRef = opts?.windowRef as Env['window'] | undefined;
+  const globalName = opts?.globalName || 'd8a';
+  const dataLayerName = opts?.dataLayerName || 'd8aLayer';
+
+  if (windowRef) {
+    windowRef[dataLayerName] = windowRef[dataLayerName] || [];
+    windowRef[globalName] = windowRef[globalName] || createD8a();
+  }
+
+  return {
+    dataLayerName,
+    globalName,
+    consumer: {
+      start: () => {},
+      stop: () => {},
+      getState: () => ({}),
+      setOnEvent: () => {},
+      setOnConfig: () => {},
+    },
+    dispatcher: {
+      enqueueEvent: () => {},
+      flush: async () => ({ sent: 0 }),
+      flushNow: async () => ({ sent: 0 }),
+      attachLifecycleFlush: () => {},
+    },
+  };
+};
+
+export const init: Env = {
+  installD8a,
+  window: {},
+};
+
+export const push: Env = {
+  installD8a,
+  window: {
+    d8a: createD8a(),
+    d8aLayer: [],
+  },
+};
+
+export const simulation = ['call:window.d8a'];

--- a/packages/web/destinations/d8a/src/examples/index.ts
+++ b/packages/web/destinations/d8a/src/examples/index.ts
@@ -1,0 +1,2 @@
+export * as env from './env';
+export * as step from './step';

--- a/packages/web/destinations/d8a/src/examples/step.ts
+++ b/packages/web/destinations/d8a/src/examples/step.ts
@@ -1,0 +1,177 @@
+import type { Flow } from '@walkeros/core';
+import { getEvent, isObject } from '@walkeros/core';
+
+const INIT_DATE_MS = 1700000000000;
+const INIT_DATE = new Date(INIT_DATE_MS);
+const PROPERTY_ID = '80e1d6d0-560d-419f-ac2a-fe9281e93386';
+const SERVER_CONTAINER_URL =
+  'https://global.t.d8a.tech/80e1d6d0-560d-419f-ac2a-fe9281e93386/d/c';
+
+export const init: Flow.StepExample = {
+  title: 'Initialization',
+  description:
+    'The destination installs d8a and configures a property with its server container URL.',
+  in: {
+    settings: {
+      property_id: PROPERTY_ID,
+      server_container_url: SERVER_CONTAINER_URL,
+    },
+  },
+  out: [
+    ['d8a', 'js', INIT_DATE],
+    [
+      'd8a',
+      'config',
+      PROPERTY_ID,
+      { server_container_url: SERVER_CONTAINER_URL },
+    ],
+  ],
+};
+
+export const pageView: Flow.StepExample = {
+  title: 'Page view',
+  description: 'A page view event is forwarded as a d8a page_view event.',
+  in: getEvent('page view', { timestamp: 1700000300 }),
+  mapping: undefined,
+  out: [['d8a', 'event', 'page_view', { send_to: PROPERTY_ID }]],
+};
+
+export const addToCart: Flow.StepExample = {
+  title: 'Add to cart',
+  description:
+    'A product add event is mapped to the d8a add_to_cart event with item details and value.',
+  in: getEvent('product add', { timestamp: 1700000301 }),
+  mapping: {
+    name: 'add_to_cart',
+    include: ['data'],
+    data: {
+      map: {
+        currency: { value: 'EUR', key: 'data.currency' },
+        value: 'data.price',
+        items: {
+          loop: [
+            'this',
+            {
+              map: {
+                item_id: 'data.id',
+                item_variant: 'data.color',
+                quantity: { value: 1, key: 'data.quantity' },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+  out: [
+    [
+      'd8a',
+      'event',
+      'add_to_cart',
+      {
+        currency: 'EUR',
+        value: 420,
+        items: [{ item_id: 'ers', item_variant: 'black', quantity: 1 }],
+        data_id: 'ers',
+        data_name: 'Everyday Ruck Snack',
+        data_color: 'black',
+        data_size: 'l',
+        data_price: 420,
+        send_to: PROPERTY_ID,
+      },
+    ],
+  ],
+};
+
+export const purchase: Flow.StepExample = {
+  title: 'Purchase',
+  description:
+    'An order complete event is mapped to the d8a purchase event with transaction details and nested product items.',
+  in: getEvent('order complete', { timestamp: 1700000302 }),
+  mapping: {
+    name: 'purchase',
+    include: ['data', 'context'],
+    data: {
+      map: {
+        transaction_id: 'data.id',
+        value: 'data.total',
+        tax: 'data.taxes',
+        shipping: 'data.shipping',
+        currency: { key: 'data.currency', value: 'EUR' },
+        items: {
+          loop: [
+            'nested',
+            {
+              condition: (entity: unknown) => {
+                const candidate = entity as { entity?: unknown };
+                return isObject(entity) && candidate.entity === 'product';
+              },
+              map: {
+                item_id: 'data.id',
+                item_name: 'data.name',
+                quantity: { key: 'data.quantity', value: 1 },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+  out: [
+    [
+      'd8a',
+      'event',
+      'purchase',
+      {
+        transaction_id: '0rd3r1d',
+        value: 555,
+        tax: 73.76,
+        shipping: 5.22,
+        currency: 'EUR',
+        items: [
+          { item_id: 'ers', item_name: 'Everyday Ruck Snack', quantity: 1 },
+          { item_id: 'cc', item_name: 'Cool Cap', quantity: 1 },
+        ],
+        data_id: '0rd3r1d',
+        data_currency: 'EUR',
+        data_shipping: 5.22,
+        data_taxes: 73.76,
+        data_total: 555,
+        context_shopping: 'complete',
+        send_to: PROPERTY_ID,
+      },
+    ],
+  ],
+};
+
+export const consentMode: Flow.StepExample = {
+  title: 'Consent mode',
+  description:
+    'A walker consent command updates d8a using gtag consent mode parameters.',
+  command: 'consent',
+  in: { marketing: true, functional: true },
+  out: [
+    [
+      'd8a',
+      'consent',
+      'default',
+      {
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+        analytics_storage: 'denied',
+      },
+    ],
+    [
+      'd8a',
+      'consent',
+      'update',
+      {
+        ad_storage: 'granted',
+        ad_user_data: 'granted',
+        ad_personalization: 'granted',
+        analytics_storage: 'granted',
+      },
+    ],
+  ],
+};

--- a/packages/web/destinations/d8a/src/index.test.ts
+++ b/packages/web/destinations/d8a/src/index.test.ts
@@ -1,0 +1,127 @@
+import type { Destination, WalkerOS } from '@walkeros/core';
+import type { D8aFn, InstallD8aOptions, InstallD8aResult } from '@d8a-tech/wt';
+import { startFlow } from '@walkeros/collector';
+import { examples } from './dev';
+import { resetConsentState } from './index';
+import type { Env } from './types';
+
+const INIT_DATE_MS = 1700000000000;
+
+type CallRecord = [string, ...unknown[]];
+
+const initExample = examples.step.init;
+const initIn = initExample.in as Destination.Config;
+const initOut = (initExample.out ?? []) as ReadonlyArray<CallRecord>;
+
+const noopLogger = {
+  log: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  throw: (msg: string) => {
+    throw new Error(msg);
+  },
+} as unknown as Destination.Context['logger'];
+
+function createInstallD8a(calls: CallRecord[]): Env['installD8a'] {
+  return (opts?: InstallD8aOptions): InstallD8aResult => {
+    const windowRef = opts?.windowRef as Env['window'];
+    const globalName = opts?.globalName || 'd8a';
+    const dataLayerName = opts?.dataLayerName || 'd8aLayer';
+    const d8a = jest.fn((...args: unknown[]) => {
+      calls.push(['d8a', ...args]);
+    }) as unknown as D8aFn;
+
+    d8a.js = jest.fn();
+    d8a.config = jest.fn();
+    d8a.event = jest.fn();
+    d8a.set = jest.fn();
+    d8a.consent = jest.fn();
+
+    windowRef[dataLayerName] = windowRef[dataLayerName] || [];
+    windowRef[globalName] = d8a;
+
+    return {
+      dataLayerName,
+      globalName,
+      consumer: {
+        start: () => {},
+        stop: () => {},
+        getState: () => ({}),
+        setOnEvent: () => {},
+        setOnConfig: () => {},
+      },
+      dispatcher: {
+        enqueueEvent: () => {},
+        flush: async () => ({ sent: 0 }),
+        flushNow: async () => ({ sent: 0 }),
+        attachLifecycleFlush: () => {},
+      },
+    };
+  };
+}
+
+function makeTestEnv(): { env: Env; calls: CallRecord[] } {
+  const calls: CallRecord[] = [];
+  return {
+    calls,
+    env: {
+      installD8a: createInstallD8a(calls),
+      window: {},
+    },
+  };
+}
+
+describe('d8a web destination -- step examples', () => {
+  beforeEach(() => {
+    resetConsentState();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(INIT_DATE_MS));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('init', async () => {
+    const { env, calls } = makeTestEnv();
+    const dest = jest.requireActual('./').default;
+
+    await dest.init({
+      id: 'd8a',
+      config: initIn,
+      env,
+      logger: noopLogger,
+      collector: {} as Destination.Context['collector'],
+    });
+
+    expect(calls).toEqual(initOut);
+  });
+
+  const stepEntries = Object.entries(examples.step).filter(
+    ([name]) => name !== 'init',
+  );
+
+  it.each(stepEntries)('%s', async (_name, example) => {
+    const { env, calls } = makeTestEnv();
+    const dest = jest.requireActual('./').default;
+    const { elb } = await startFlow();
+
+    const event = example.in as WalkerOS.Event;
+    const mapping = example.mapping
+      ? { [event.entity]: { [event.action]: example.mapping } }
+      : undefined;
+
+    await elb('walker destination', { ...dest, env }, { ...initIn, mapping });
+
+    if (example.command) {
+      const cmd = `walker ${example.command}` as 'walker consent';
+      await elb(cmd, example.in as WalkerOS.Consent);
+    } else {
+      await elb(event);
+    }
+
+    const actual = calls.slice(initOut.length);
+    expect(actual).toEqual(example.out);
+  });
+});

--- a/packages/web/destinations/d8a/src/index.test.ts
+++ b/packages/web/destinations/d8a/src/index.test.ts
@@ -1,3 +1,32 @@
+// The real @d8a-tech/wt package is ESM and can't be parsed by Jest's
+// default CommonJS transformer. Tests always wire their own mock via
+// `env.installD8a`, so the real module is never invoked — we stub the
+// import with a no-op installer to let Jest load the destination file.
+jest.mock(
+  '@d8a-tech/wt',
+  () => ({
+    __esModule: true,
+    installD8a: () => ({
+      dataLayerName: 'd8aLayer',
+      globalName: 'd8a',
+      consumer: {
+        start: () => {},
+        stop: () => {},
+        getState: () => ({}),
+        setOnEvent: () => {},
+        setOnConfig: () => {},
+      },
+      dispatcher: {
+        enqueueEvent: () => {},
+        flush: async () => ({ sent: 0 }),
+        flushNow: async () => ({ sent: 0 }),
+        attachLifecycleFlush: () => {},
+      },
+    }),
+  }),
+  { virtual: true },
+);
+
 import type { Destination, WalkerOS } from '@walkeros/core';
 import type { D8aFn, InstallD8aOptions, InstallD8aResult } from '@d8a-tech/wt';
 import { startFlow } from '@walkeros/collector';
@@ -112,7 +141,10 @@ describe('d8a web destination -- step examples', () => {
       ? { [event.entity]: { [event.action]: example.mapping } }
       : undefined;
 
-    await elb('walker destination', { ...dest, env }, { ...initIn, mapping });
+    elb('walker destination', {
+      code: { ...dest, env },
+      config: { ...initIn, mapping },
+    });
 
     if (example.command) {
       const cmd = `walker ${example.command}` as 'walker consent';

--- a/packages/web/destinations/d8a/src/index.ts
+++ b/packages/web/destinations/d8a/src/index.ts
@@ -1,7 +1,8 @@
 import type { WalkerOS } from '@walkeros/core';
 import { isObject } from '@walkeros/core';
 import { getEnv } from '@walkeros/web-core';
-import type { D8aConfigParams, D8aFn, installD8a } from '@d8a-tech/wt';
+import type { D8aConfigParams, D8aFn } from '@d8a-tech/wt';
+import { installD8a } from '@d8a-tech/wt';
 import type { ConsentMapping, Destination, Settings } from './types';
 import { getData, normalizeEventName } from './mapping';
 
@@ -58,13 +59,7 @@ export const destinationD8a: Destination = {
     const { window } = getEnv(env);
     const globalName = settings.globalName || DEFAULT_GLOBAL_NAME;
     const dataLayerName = settings.dataLayerName || DEFAULT_DATA_LAYER_NAME;
-    const installD8aFn: typeof installD8a =
-      env?.installD8a ||
-      (
-        (await new Function('specifier', 'return import(specifier)')(
-          '@d8a-tech/wt',
-        )) as { installD8a: typeof installD8a }
-      ).installD8a;
+    const installD8aFn = env?.installD8a || installD8a;
 
     installD8aFn({
       windowRef: window,

--- a/packages/web/destinations/d8a/src/index.ts
+++ b/packages/web/destinations/d8a/src/index.ts
@@ -1,0 +1,159 @@
+import type { WalkerOS } from '@walkeros/core';
+import { isObject } from '@walkeros/core';
+import { getEnv } from '@walkeros/web-core';
+import type { D8aConfigParams, D8aFn, installD8a } from '@d8a-tech/wt';
+import type { ConsentMapping, Destination, Settings } from './types';
+import { getData, normalizeEventName } from './mapping';
+
+export * as DestinationD8a from './types';
+
+const DEFAULT_GLOBAL_NAME = 'd8a';
+const DEFAULT_DATA_LAYER_NAME = 'd8aLayer';
+
+const DEFAULT_CONSENT_MAPPING: ConsentMapping = {
+  marketing: ['ad_storage', 'ad_user_data', 'ad_personalization'],
+  functional: 'analytics_storage',
+};
+
+let defaultConsentSet = false;
+
+export function resetConsentState(): void {
+  defaultConsentSet = false;
+}
+
+function getD8a(
+  windowRef: Window & Record<string, unknown>,
+  name: string,
+): D8aFn {
+  return windowRef[name] as D8aFn;
+}
+
+function buildConfigParams(settings: Partial<Settings>): D8aConfigParams {
+  const {
+    property_id: _property_id,
+    como: _como,
+    data: _data,
+    dataLayerName: _dataLayerName,
+    globalName: _globalName,
+    snakeCase: _snakeCase,
+    ...configParams
+  } = settings;
+
+  return { ...configParams };
+}
+
+export const destinationD8a: Destination = {
+  type: 'd8a',
+
+  config: { settings: {} },
+
+  async init({ config, env, logger }) {
+    const settings = config.settings || {};
+    const { property_id, server_container_url } = settings;
+
+    if (!property_id) logger.throw('Config settings property_id missing');
+    if (!server_container_url)
+      logger.throw('Config settings server_container_url missing');
+
+    const { window } = getEnv(env);
+    const globalName = settings.globalName || DEFAULT_GLOBAL_NAME;
+    const dataLayerName = settings.dataLayerName || DEFAULT_DATA_LAYER_NAME;
+    const installD8aFn: typeof installD8a =
+      env?.installD8a ||
+      (
+        (await new Function('specifier', 'return import(specifier)')(
+          '@d8a-tech/wt',
+        )) as { installD8a: typeof installD8a }
+      ).installD8a;
+
+    installD8aFn({
+      windowRef: window,
+      globalName,
+      dataLayerName,
+    });
+
+    const d8a = getD8a(window as Window & Record<string, unknown>, globalName);
+    d8a('js', new Date());
+    d8a('config', property_id, buildConfigParams(settings));
+
+    return config;
+  },
+
+  async push(event, { config, data, env, collector }) {
+    const settings = config.settings || {};
+    const eventData = await getData(
+      event,
+      data as WalkerOS.AnyObject,
+      config,
+      settings,
+      collector,
+    );
+    const eventParams = isObject(eventData)
+      ? { ...(eventData as Record<string, unknown>) }
+      : {};
+
+    eventParams.send_to = settings.property_id;
+
+    const eventName = normalizeEventName(
+      event.name,
+      settings.snakeCase !== false,
+    );
+    const { window } = getEnv(env);
+    const globalName = settings.globalName || DEFAULT_GLOBAL_NAME;
+    const d8a = getD8a(window as Window & Record<string, unknown>, globalName);
+
+    d8a('event', eventName, eventParams);
+  },
+
+  on(type, context) {
+    if (type !== 'consent' || !context.data) return;
+
+    const settings = (context.config?.settings || {}) as Partial<Settings>;
+    const { como = true } = settings;
+    if (!como) return;
+
+    const { window } = getEnv(context.env);
+    const globalName = settings.globalName || DEFAULT_GLOBAL_NAME;
+    const d8a = getD8a(window as Window & Record<string, unknown>, globalName);
+    if (!d8a) return;
+
+    const consent = context.data as WalkerOS.Consent;
+    const consentMapping = como === true ? DEFAULT_CONSENT_MAPPING : como;
+
+    if (!defaultConsentSet) {
+      const allParams = new Set<string>();
+      Object.values(consentMapping).forEach((params) => {
+        const paramArray = Array.isArray(params) ? params : [params];
+        paramArray.forEach((param) => allParams.add(param));
+      });
+
+      if (allParams.size > 0) {
+        const defaultConsent: Record<string, 'denied'> = {};
+        allParams.forEach((param) => {
+          defaultConsent[param] = 'denied';
+        });
+        d8a('consent', 'default', defaultConsent);
+      }
+
+      defaultConsentSet = true;
+    }
+
+    const d8aConsent: Record<string, 'granted' | 'denied'> = {};
+    Object.entries(consent).forEach(([walkerOSGroup, granted]) => {
+      const d8aParams = consentMapping[walkerOSGroup];
+      if (!d8aParams) return;
+
+      const params = Array.isArray(d8aParams) ? d8aParams : [d8aParams];
+      const consentValue = granted ? 'granted' : 'denied';
+      params.forEach((param) => {
+        d8aConsent[param] = consentValue;
+      });
+    });
+
+    if (Object.keys(d8aConsent).length === 0) return;
+
+    d8a('consent', 'update', d8aConsent);
+  },
+};
+
+export default destinationD8a;

--- a/packages/web/destinations/d8a/src/mapping.ts
+++ b/packages/web/destinations/d8a/src/mapping.ts
@@ -1,0 +1,35 @@
+import type { Collector, WalkerOS } from '@walkeros/core';
+import { assign, getMappingValue, isObject } from '@walkeros/core';
+import type { Config, Settings } from './types';
+
+export function normalizeEventName(
+  eventName: string,
+  snakeCase = true,
+): string {
+  if (!snakeCase) return eventName;
+
+  return eventName.replace(/\s+/g, '_').toLowerCase();
+}
+
+export async function getData(
+  event: WalkerOS.Event,
+  data: WalkerOS.AnyObject | undefined,
+  config: Config,
+  settings: Partial<Settings> | undefined,
+  collector: Collector.Instance,
+): Promise<WalkerOS.AnyObject> {
+  const baseData = isObject(data) ? data : {};
+
+  const configMappedData = config.data
+    ? await getMappingValue(event, config.data, { collector })
+    : {};
+
+  const settingsMappedData = settings?.data
+    ? await getMappingValue(event, settings.data, { collector })
+    : {};
+
+  const configData = isObject(configMappedData) ? configMappedData : {};
+  const settingsData = isObject(settingsMappedData) ? settingsMappedData : {};
+
+  return assign(assign(baseData, configData), settingsData);
+}

--- a/packages/web/destinations/d8a/src/schemas/index.ts
+++ b/packages/web/destinations/d8a/src/schemas/index.ts
@@ -1,0 +1,9 @@
+import { zodToSchema } from '@walkeros/core/dev';
+import { MappingSchema } from './mapping';
+import { SettingsSchema } from './settings';
+
+export { MappingSchema, type Mapping } from './mapping';
+export { SettingsSchema, type Settings } from './settings';
+
+export const settings = zodToSchema(SettingsSchema);
+export const mapping = zodToSchema(MappingSchema);

--- a/packages/web/destinations/d8a/src/schemas/mapping.ts
+++ b/packages/web/destinations/d8a/src/schemas/mapping.ts
@@ -1,0 +1,5 @@
+import { z } from '@walkeros/core/dev';
+
+export const MappingSchema = z.object({});
+
+export type Mapping = z.infer<typeof MappingSchema>;

--- a/packages/web/destinations/d8a/src/schemas/primitives.ts
+++ b/packages/web/destinations/d8a/src/schemas/primitives.ts
@@ -16,7 +16,7 @@ export const SettingsSchema = z.object({
   como: ConsentModeSchema.describe(
     'Consent mode configuration: false (disabled), true (use defaults), or custom mapping',
   ).optional(),
-  data: z.any().describe('Custom data mapping configuration').optional(),
+  data: z.unknown().describe('Custom data mapping configuration').optional(),
   dataLayerName: z
     .string()
     .describe('Name of the d8a command queue (default: d8aLayer)')

--- a/packages/web/destinations/d8a/src/schemas/primitives.ts
+++ b/packages/web/destinations/d8a/src/schemas/primitives.ts
@@ -1,0 +1,85 @@
+import { z } from '@walkeros/core/dev';
+
+export const ConsentModeSchema = z.union([
+  z.boolean(),
+  z.record(z.string(), z.union([z.string(), z.array(z.string())])),
+]);
+
+const csvOrArray = z.union([z.string(), z.array(z.string())]);
+
+export const SettingsSchema = z.object({
+  property_id: z.string().describe('d8a property ID'),
+  server_container_url: z
+    .string()
+    .url()
+    .describe('d8a collector URL for the property'),
+  como: ConsentModeSchema.describe(
+    'Consent mode configuration: false (disabled), true (use defaults), or custom mapping',
+  ).optional(),
+  data: z.any().describe('Custom data mapping configuration').optional(),
+  dataLayerName: z
+    .string()
+    .describe('Name of the d8a command queue (default: d8aLayer)')
+    .optional(),
+  globalName: z
+    .string()
+    .describe('Name of the global d8a function (default: d8a)')
+    .optional(),
+  send_page_view: z
+    .boolean()
+    .describe('Enable automatic pageview tracking')
+    .optional(),
+  snakeCase: z
+    .boolean()
+    .describe('Convert event names to snake_case (like true)')
+    .optional(),
+  debug_mode: z.boolean().describe('Enable debug mode').optional(),
+  cookie_domain: z
+    .string()
+    .describe('Cookie domain strategy: auto, none, or a specific domain')
+    .optional(),
+  cookie_path: z.string().describe('Cookie path').optional(),
+  cookie_expires: z.number().describe('Cookie lifetime in seconds').optional(),
+  cookie_flags: z.string().describe('Raw cookie flags').optional(),
+  cookie_prefix: z.string().describe('Cookie name prefix').optional(),
+  cookie_update: z
+    .boolean()
+    .describe('Refresh cookie expirations on activity')
+    .optional(),
+  session_timeout_ms: z
+    .number()
+    .describe('Session timeout window in milliseconds')
+    .optional(),
+  session_engagement_time_sec: z
+    .number()
+    .describe('Minimum engaged time in seconds')
+    .optional(),
+  flush_interval_ms: z
+    .number()
+    .describe('Flush interval in milliseconds')
+    .optional(),
+  max_batch_size: z.number().describe('Maximum batch size').optional(),
+  user_id: z.string().describe('GA4-style user ID').optional(),
+  client_id: z.string().describe('Client ID override').optional(),
+  campaign_id: z.string().optional(),
+  campaign_source: z.string().optional(),
+  campaign_medium: z.string().optional(),
+  campaign_name: z.string().optional(),
+  campaign_term: z.string().optional(),
+  campaign_content: z.string().optional(),
+  page_location: z.string().optional(),
+  page_title: z.string().optional(),
+  page_referrer: z.string().optional(),
+  content_group: z.string().optional(),
+  language: z.string().optional(),
+  screen_resolution: z.string().optional(),
+  ignore_referrer: z.boolean().optional(),
+  site_search_enabled: z.boolean().optional(),
+  site_search_query_params: csvOrArray.optional(),
+  outbound_clicks_enabled: z.boolean().optional(),
+  outbound_exclude_domains: csvOrArray.optional(),
+  file_downloads_enabled: z.boolean().optional(),
+  file_download_extensions: csvOrArray.optional(),
+});
+
+export type Settings = z.infer<typeof SettingsSchema>;

--- a/packages/web/destinations/d8a/src/schemas/settings.ts
+++ b/packages/web/destinations/d8a/src/schemas/settings.ts
@@ -1,0 +1,1 @@
+export { SettingsSchema, type Settings } from './primitives';

--- a/packages/web/destinations/d8a/src/types/index.ts
+++ b/packages/web/destinations/d8a/src/types/index.ts
@@ -1,0 +1,58 @@
+import type {
+  Destination as CoreDestination,
+  Mapping as WalkerOSMapping,
+} from '@walkeros/core';
+import type { DestinationWeb } from '@walkeros/web-core';
+import type {
+  D8aConfigParams,
+  D8aEventParams,
+  D8aFn,
+  InstallD8aOptions,
+  InstallD8aResult,
+} from '@d8a-tech/wt';
+
+declare global {
+  interface Window {
+    d8a?: D8aFn;
+    d8aLayer?: unknown[];
+    d8aDataLayerName?: string;
+    d8aGlobalName?: string;
+  }
+}
+
+export type ConsentMode = false | true | ConsentMapping;
+
+export interface ConsentMapping {
+  [walkerOSConsentGroup: string]: string | string[];
+}
+
+export interface Settings extends D8aConfigParams {
+  property_id: string;
+  server_container_url: string;
+  como?: ConsentMode;
+  data?: WalkerOSMapping.Value | WalkerOSMapping.Values;
+  dataLayerName?: string;
+  globalName?: string;
+  snakeCase?: boolean;
+}
+
+export type InitSettings = Partial<Settings>;
+
+export interface Mapping {}
+
+export interface Env extends DestinationWeb.Env {
+  installD8a?: (opts?: InstallD8aOptions) => InstallD8aResult;
+  window: DestinationWeb.Env['window'] & {
+    d8a?: D8aFn;
+    d8aLayer?: unknown[];
+    [key: string]: unknown;
+  };
+}
+
+export type Types = CoreDestination.Types<Settings, Mapping, Env, InitSettings>;
+
+export type Destination = DestinationWeb.Destination<Types>;
+export type Config = DestinationWeb.Config<Types>;
+export type Rule = WalkerOSMapping.Rule<Mapping>;
+export type Rules = WalkerOSMapping.Rules<Rule>;
+export type Parameters = D8aEventParams;

--- a/packages/web/destinations/d8a/tsconfig.json
+++ b/packages/web/destinations/d8a/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@walkeros/config/tsconfig/web.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/web/destinations/d8a/tsup.config.ts
+++ b/packages/web/destinations/d8a/tsup.config.ts
@@ -1,0 +1,18 @@
+import {
+  defineConfig,
+  buildModules,
+  buildExamples,
+  buildBrowser,
+  buildES5,
+  buildDev,
+} from '@walkeros/config/tsup';
+
+const globalName = 'Destination';
+
+export default defineConfig([
+  buildModules(),
+  buildExamples(),
+  buildBrowser({ globalName }),
+  buildES5({ globalName }),
+  buildDev(),
+]);


### PR DESCRIPTION
Hi @alexanderkirtzel. Please treat this PR/issue as the start of a discussion. I tested it in browser mode, which required me to build the packages locally. During that process, I had to pin an older version of Turbo. I'm not entirely sure if that's the best approach, so let me know what you think!

By design, this should be very similar to the gtag destination, just simplified since we don't need Google Tag Manager or Ads support. Even the consent mode is handled the same way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New d8a web destination providing GA4-compatible event tracking and warehouse-native delivery.
  * Configurable event-to-d8a mapping, consent-mode support, and customizable data layer/global names.

* **Documentation**
  * Comprehensive setup guide, configuration reference, consent examples, and step-by-step usage examples for initialization and common events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elbwalker/walkerOS/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->