### PR TITLE
647 extend and remove mapping rules

### DIFF
--- a/.changeset/cli-simulation-result.md
+++ b/.changeset/cli-simulation-result.md
@@ -1,0 +1,9 @@
+---
+'@walkeros/cli': patch
+---
+
+The simulate functions (`simulateSource`, `simulateTransformer`,
+`simulateDestination`) now return the unified `Simulation.Result` shape with
+captured `events` and intercepted `calls`, instead of the internal push result.
+`PushResult` no longer carries the simulate-only `captured`, `usage`, and
+`perDestination` fields.

--- a/.changeset/contract-extend-rename.md
+++ b/.changeset/contract-extend-rename.md
@@ -1,0 +1,8 @@
+---
+'@walkeros/core': patch
+'@walkeros/cli': patch
+---
+
+Rename the contract inheritance key from `extends` to `extend` for consistency
+with the rest of the flow config vocabulary. Contracts that inherit from another
+named contract now use `"extend": "<name>"`.

--- a/.changeset/explorer-completion-builders.md
+++ b/.changeset/explorer-completion-builders.md
@@ -1,0 +1,8 @@
+---
+'@walkeros/explorer': patch
+---
+
+Export the `$`-ref completion builders (`getVariableCompletions`,
+`getEnvCompletions`, `getStoreCompletions`, `getFlowCompletions`,
+`getSecretCompletions`) and the `CompletionEntry` type from the package barrel
+so custom inputs can reuse them outside Monaco.

--- a/.changeset/explorer-mapping-contract-completions.md
+++ b/.changeset/explorer-mapping-contract-completions.md
@@ -1,0 +1,10 @@
+---
+'@walkeros/explorer': patch
+---
+
+Export `getMappingPathCompletions` and `getContractCompletions` so custom form
+inputs can seed contract-driven path and `$contract` reference suggestions
+outside Monaco. Add `allowedRefKinds` (the cursor-scoped `$`-ref gate, now
+covering `$contract`) and `getJsonPathAtOffset`, and gate the open `$`
+completion fallback by the same scope rule so Monaco offers only the ref kinds
+valid at the cursor.

--- a/.changeset/mapping-extend-remove.md
+++ b/.changeset/mapping-extend-remove.md
@@ -1,0 +1,9 @@
+---
+'@walkeros/core': minor
+'@walkeros/transformer-ga4': minor
+---
+
+Add `extend` and `remove` to mapping rules. `extend` deep-merges a partial rule
+onto a package-shipped default (a `null` value clears an inherited field);
+`remove` strips fields from the produced payload. Rules without either keyword
+keep the existing replace behavior.

--- a/.changeset/meta-capi-auth-header.md
+++ b/.changeset/meta-capi-auth-header.md
@@ -1,0 +1,7 @@
+---
+'@walkeros/server-destination-meta': patch
+---
+
+Send the Conversions API access token in an `Authorization: Bearer` header
+instead of the URL query string, so the credential no longer appears in server,
+proxy, or APM request logs.

--- a/.changeset/storybook-addon-typecheck.md
+++ b/.changeset/storybook-addon-typecheck.md
@@ -1,0 +1,6 @@
+---
+'@walkeros/storybook-addon': patch
+---
+
+Fix latent type errors in Panel props and attribute tree builder, and enable
+`typecheck` script so the package participates in CI type coverage.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: release
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -28,7 +28,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
       # so we take it from the runtime rather than self-upgrading a running npm
       # in place (which is fragile). Pin the version; bump it deliberately.
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.15.0'
           registry-url: 'https://registry.npmjs.org'
@@ -210,14 +210,14 @@ jobs:
         if:
           steps.check-flow.outputs.exists == 'false' ||
           steps.check-cli.outputs.exists == 'false'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Flow image
         if: steps.check-flow.outputs.exists == 'false'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./packages/cli
           file: ./packages/cli/Dockerfile
@@ -230,7 +230,7 @@ jobs:
 
       - name: Build and push CLI image
         if: steps.check-cli.outputs.exists == 'false'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./packages/cli
           file: ./packages/cli/Dockerfile.cli

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -20,9 +20,9 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.15.0'
           cache: 'npm'

--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -16,9 +16,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.15.0'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,8 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.15.0'
           cache: 'npm'
@@ -56,7 +56,7 @@ jobs:
         run: npm run test:integration
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-results-${{ github.run_id }}
           path: |

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -25,9 +25,9 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.15.0'
           cache: 'npm'
@@ -66,10 +66,13 @@ jobs:
 
       - name: Comment PR with preview URL
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          BUNNY_PULLZONE_URL: ${{ secrets.BUNNY_WEBSITE_PULLZONE_URL }}
+          PR_NUM: ${{ github.event.pull_request.number }}
         with:
           script: |
-            const previewUrl = `${{ secrets.BUNNY_WEBSITE_PULLZONE_URL }}/preview/pr-${{ github.event.pull_request.number }}/`;
+            const previewUrl = `${process.env.BUNNY_PULLZONE_URL}/preview/pr-${process.env.PR_NUM}/`;
             const body = `### Preview deployed\n\n${previewUrl}`;
 
             // Find existing comment
@@ -103,13 +106,21 @@ jobs:
       - name: Delete preview folder
         run: |
           curl -X DELETE \
-            "https://storage.bunnycdn.com/${{ secrets.BUNNY_WEBSITE_STORAGE_ZONE }}/preview/pr-${{ github.event.pull_request.number }}/" \
-            -H "AccessKey: ${{ secrets.BUNNY_WEBSITE_STORAGE_PASSWORD }}"
-          echo "Deleted preview/pr-${{ github.event.pull_request.number }}/"
+            "https://storage.bunnycdn.com/${BUNNY_STORAGE_ZONE}/preview/pr-${PR_NUMBER}/" \
+            -H "AccessKey: ${BUNNY_STORAGE_PASSWORD}"
+          echo "Deleted preview/pr-${PR_NUMBER}/"
+        env:
+          BUNNY_STORAGE_ZONE: ${{ secrets.BUNNY_WEBSITE_STORAGE_ZONE }}
+          BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_WEBSITE_STORAGE_PASSWORD }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Purge preview cache
         run: |
           curl -X POST \
-            "https://api.bunny.net/purge?url=$(echo '${{ secrets.BUNNY_WEBSITE_PULLZONE_URL }}/preview/pr-${{ github.event.pull_request.number }}/*' | jq -sRr @uri)" \
-            -H "AccessKey: ${{ secrets.BUNNY_API_KEY }}"
+            "https://api.bunny.net/purge?url=$(echo "${BUNNY_PULLZONE_URL}/preview/pr-${PR_NUMBER}/*" | jq -sRr @uri)" \
+            -H "AccessKey: ${BUNNY_API_KEY}"
           echo "Cache purged"
+        env:
+          BUNNY_PULLZONE_URL: ${{ secrets.BUNNY_WEBSITE_PULLZONE_URL }}
+          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/apps/explorer/src/index.ts
+++ b/apps/explorer/src/index.ts
@@ -82,6 +82,24 @@ export type { SpinnerProps } from './components/atoms/spinner';
 // Utils
 export { isMonacoCancellation } from './utils/is-monaco-cancellation';
 
+// `$`-ref completion builders (no Monaco dependency) for reuse in custom inputs
+export {
+  getVariableCompletions,
+  getEnvCompletions,
+  getStoreCompletions,
+  getFlowCompletions,
+  getSecretCompletions,
+  getMappingPathCompletions,
+  getContractCompletions,
+} from './utils/monaco-walkeros-completions';
+export type { CompletionEntry } from './utils/monaco-walkeros-completions';
+
+// Cursor-scoped `$`-ref gate + JSON path helper. One pure gate shared by Monaco
+// (subPath derived live) and Form fields (subPath passed statically).
+export { allowedRefKinds } from './utils/allowed-ref-kinds';
+export type { RefKind } from './utils/allowed-ref-kinds';
+export { getJsonPathAtOffset } from './utils/monaco-json-path';
+
 // MDX Integration
 export { MDXProvider } from './providers/MDXProvider';
 export { MDXCode } from './components/atoms/mdx-code';

--- a/apps/explorer/src/utils/__tests__/allowed-ref-kinds.test.ts
+++ b/apps/explorer/src/utils/__tests__/allowed-ref-kinds.test.ts
@@ -1,0 +1,36 @@
+import { allowedRefKinds } from '../allowed-ref-kinds';
+
+describe('allowedRefKinds', () => {
+  it('offers var/env/secret broadly', () => {
+    expect(allowedRefKinds('destination', ['config'])).toEqual(
+      expect.arrayContaining(['var', 'env', 'secret']),
+    );
+  });
+
+  it('offers store only under env', () => {
+    expect(allowedRefKinds('destination', ['config', 'env'])).toContain(
+      'store',
+    );
+    expect(
+      allowedRefKinds('destination', ['config', 'settings']),
+    ).not.toContain('store');
+  });
+
+  it('offers flow only in settings/env of source/destination', () => {
+    expect(allowedRefKinds('destination', ['config', 'settings'])).toContain(
+      'flow',
+    );
+    expect(
+      allowedRefKinds('transformer', ['config', 'settings']),
+    ).not.toContain('flow');
+  });
+
+  it('offers contract only at a validate-events value', () => {
+    expect(
+      allowedRefKinds('destination', ['validate', 'events', 'product', 'view']),
+    ).toContain('contract');
+    expect(allowedRefKinds('destination', ['config'])).not.toContain(
+      'contract',
+    );
+  });
+});

--- a/apps/explorer/src/utils/__tests__/contract-path-walker.test.ts
+++ b/apps/explorer/src/utils/__tests__/contract-path-walker.test.ts
@@ -33,7 +33,7 @@ const sampleContract: Flow.Contract = {
     },
   },
   web: {
-    extends: 'default',
+    extend: 'default',
     events: {
       page: {
         view: {
@@ -66,8 +66,8 @@ describe('getContractPathCompletions', () => {
     expect(keys).toEqual(
       expect.arrayContaining(['description', 'schema', 'events']),
     );
-    // extends is stripped after resolution
-    expect(keys).not.toContain('extends');
+    // extend is stripped after resolution
+    expect(keys).not.toContain('extend');
   });
 
   it('returns entity names under events', () => {

--- a/apps/explorer/src/utils/__tests__/monaco-walkeros-completions.test.ts
+++ b/apps/explorer/src/utils/__tests__/monaco-walkeros-completions.test.ts
@@ -157,7 +157,7 @@ describe('getContractCompletions', () => {
         },
       },
     },
-    web: { extends: 'default' },
+    web: { extend: 'default' },
   };
 
   it('returns contract names for empty path', () => {

--- a/apps/explorer/src/utils/allowed-ref-kinds.ts
+++ b/apps/explorer/src/utils/allowed-ref-kinds.ts
@@ -1,0 +1,37 @@
+import type { IntelliSenseContext } from '../types/intellisense';
+
+/** The `$`-ref kinds the completion gate can offer. Mirrors core's ref families. */
+export type RefKind = 'var' | 'env' | 'store' | 'flow' | 'secret' | 'contract';
+
+/**
+ * Single pure scope gate for `$`-ref completion, shared by Monaco (subPath derived
+ * live from the cursor) and every Form field (subPath passed statically):
+ * - `$var`/`$env`/`$secret` broadly
+ * - `$store` only under an `env` subPath
+ * - `$flow` only in settings/env of source/destination
+ * - `$contract` only at a `validate.events.<entity>.<action>` value path
+ */
+export function allowedRefKinds(
+  nodeType: IntelliSenseContext['nodeType'],
+  subPath: string[] = [],
+): RefKind[] {
+  const kinds: RefKind[] = ['var', 'env', 'secret'];
+  const inEnv = subPath.includes('env');
+  const inSettings = subPath.includes('settings');
+
+  if (inEnv) kinds.push('store');
+
+  const isSourceOrDest = nodeType === 'source' || nodeType === 'destination';
+  if (isSourceOrDest && (inSettings || inEnv)) kinds.push('flow');
+
+  // `$contract` resolves at a validate-events value, i.e. under
+  // validate.events.<entity>.<action>.
+  const validateIndex = subPath.indexOf('validate');
+  const inValidateEvents =
+    validateIndex >= 0 && subPath[validateIndex + 1] === 'events';
+  if (inValidateEvents && subPath.length >= validateIndex + 4) {
+    kinds.push('contract');
+  }
+
+  return kinds;
+}

--- a/apps/explorer/src/utils/monaco-walkeros-providers.ts
+++ b/apps/explorer/src/utils/monaco-walkeros-providers.ts
@@ -134,36 +134,49 @@ export function registerWalkerOSProviders(
 
         const entries: CompletionEntry[] = [];
 
+        // Single scope gate shared by the explicit `$kind.` branches and the
+        // open-`$` fallback. An explicit ref prefix that is not allowed at this
+        // location yields no suggestions, matching the Form fields' behavior so
+        // filtering is consistent however the ref is typed.
+        const subPath = getJsonPathAtOffset(fullText, offset);
+        const kinds = allowedRefKinds(context.nodeType, subPath);
+
         if (
           textBeforeCursor.includes('$var.') ||
           textBeforeCursor.endsWith('"$var')
         ) {
+          if (!kinds.includes('var')) return { suggestions: [] };
           entries.push(...getVariableCompletions(context.variables));
         } else if (
           textBeforeCursor.includes('$secret.') ||
           textBeforeCursor.endsWith('"$secret')
         ) {
+          if (!kinds.includes('secret')) return { suggestions: [] };
           entries.push(...getSecretCompletions(context.secrets));
         } else if (
           textBeforeCursor.includes('$store.') ||
           textBeforeCursor.endsWith('"$store')
         ) {
+          if (!kinds.includes('store')) return { suggestions: [] };
           entries.push(...getStoreCompletions(context.stores));
         } else if (
           textBeforeCursor.includes('$flow.') ||
           textBeforeCursor.endsWith('"$flow')
         ) {
+          if (!kinds.includes('flow')) return { suggestions: [] };
           entries.push(...getFlowCompletions(context.flows));
         } else if (
           textBeforeCursor.includes('$env.') ||
           textBeforeCursor.endsWith('"$env')
         ) {
+          if (!kinds.includes('env')) return { suggestions: [] };
           entries.push(...getEnvCompletions(context.envNames));
         } else if (
           (textBeforeCursor.includes('$contract.') ||
             textBeforeCursor.endsWith('"$contract')) &&
           isAtContractValueStart(model, position)
         ) {
+          if (!kinds.includes('contract')) return { suggestions: [] };
           // Extract the partial path typed so far after the "$contract."
           // prefix. This is a UI extraction helper (looser character class
           // than REF_CONTRACT because the user may be mid-typing), so it
@@ -187,11 +200,8 @@ export function registerWalkerOSProviders(
           textBeforeCursor.endsWith('"$') ||
           textBeforeCursor.endsWith('"')
         ) {
-          // Gate the open `$` fallback by the same pure scope rule the Form
-          // fields use: derive the subPath at the cursor, then offer only the
-          // ref kinds allowed at that location.
-          const subPath = getJsonPathAtOffset(fullText, offset);
-          const kinds = allowedRefKinds(context.nodeType, subPath);
+          // Open `$`: reuse the scope gate computed above and offer every ref
+          // kind allowed at this location.
           if (kinds.includes('var'))
             entries.push(...getVariableCompletions(context.variables));
           if (kinds.includes('secret'))

--- a/apps/explorer/src/utils/monaco-walkeros-providers.ts
+++ b/apps/explorer/src/utils/monaco-walkeros-providers.ts
@@ -20,6 +20,7 @@ import {
   type CompletionEntry,
 } from './monaco-walkeros-completions';
 import { getJsonPathAtOffset } from './monaco-json-path';
+import { allowedRefKinds } from './allowed-ref-kinds';
 import { detectMappingContext } from './mapping-context-detector';
 import {
   detectChainRefContext,
@@ -186,12 +187,23 @@ export function registerWalkerOSProviders(
           textBeforeCursor.endsWith('"$') ||
           textBeforeCursor.endsWith('"')
         ) {
-          entries.push(...getVariableCompletions(context.variables));
-          entries.push(...getSecretCompletions(context.secrets));
-          entries.push(...getStoreCompletions(context.stores));
-          entries.push(...getFlowCompletions(context.flows));
-          entries.push(...getEnvCompletions(context.envNames));
-          entries.push(...getContractCompletions(context.contractRaw, []));
+          // Gate the open `$` fallback by the same pure scope rule the Form
+          // fields use: derive the subPath at the cursor, then offer only the
+          // ref kinds allowed at that location.
+          const subPath = getJsonPathAtOffset(fullText, offset);
+          const kinds = allowedRefKinds(context.nodeType, subPath);
+          if (kinds.includes('var'))
+            entries.push(...getVariableCompletions(context.variables));
+          if (kinds.includes('secret'))
+            entries.push(...getSecretCompletions(context.secrets));
+          if (kinds.includes('store'))
+            entries.push(...getStoreCompletions(context.stores));
+          if (kinds.includes('flow'))
+            entries.push(...getFlowCompletions(context.flows));
+          if (kinds.includes('env'))
+            entries.push(...getEnvCompletions(context.envNames));
+          if (kinds.includes('contract'))
+            entries.push(...getContractCompletions(context.contractRaw, []));
         }
 
         // Mapping value path completions (data., globals., user., etc.)

--- a/apps/storybook-addon/package.json
+++ b/apps/storybook-addon/package.json
@@ -52,6 +52,7 @@
     "build:watch": "npm run build -- --watch",
     "test": "jest",
     "lint": "eslint src --ext .ts,.tsx",
+    "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "start": "run-p build:watch \"storybook --quiet\"",
     "prerelease": "zx scripts/prepublish-checks.js",

--- a/apps/storybook-addon/src/components/Panel.tsx
+++ b/apps/storybook-addon/src/components/Panel.tsx
@@ -1,4 +1,4 @@
-import type { WalkerOSAddon, AttributeNode } from '../types';
+import type { AttributeNode } from '../types';
 import type { WalkerOS } from '@walkeros/core';
 import React, { Fragment, memo, useCallback, useEffect, useState } from 'react';
 import {
@@ -25,7 +25,6 @@ import { formatEventTitle } from '../utils/formatEventTitle';
 
 interface PanelProps {
   active: boolean;
-  walkerOSAddon: WalkerOSAddon;
 }
 
 export const Panel: React.FC<PanelProps> = memo(function MyPanel(props) {

--- a/apps/storybook-addon/src/utils/attributeTreeUtils.ts
+++ b/apps/storybook-addon/src/utils/attributeTreeUtils.ts
@@ -35,6 +35,18 @@ const generateElementHTML = (element: Element): string => {
   return `<${tagName}\n${formattedAttribs}\n></${tagName}>`;
 };
 
+// Convert a Properties map (values may be undefined) into a Property
+// object shape (values are all defined). Used when nesting a Properties
+// result as a single value in another Properties map.
+const toPropertyObject = (props: WalkerOS.Properties): WalkerOS.Property => {
+  const out: { [key: string]: WalkerOS.Property } = {};
+  for (const key of Object.keys(props)) {
+    const value = props[key];
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+};
+
 // Build attribute tree structure
 export const buildAttributeTree = (
   scope: Element,
@@ -107,7 +119,9 @@ export const buildAttributeTree = (
       if (attr.name.startsWith(`${prefix}-`)) {
         const propName = attr.name.substring(prefix.length + 1);
         try {
-          properties[propName] = getElbValues(prefix, el, propName, true);
+          properties[propName] = toPropertyObject(
+            getElbValues(prefix, el, propName, true),
+          );
         } catch (e) {
           // If parsing fails, just store the raw value
           properties[propName] = attr.value;

--- a/package-lock.json
+++ b/package-lock.json
@@ -40769,7 +40769,7 @@
     },
     "packages/web/destinations/d8a": {
       "name": "@walkeros/web-destination-d8a",
-      "version": "4.0.2",
+      "version": "4.1.0",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -40779,11 +40779,11 @@
       "license": "MIT",
       "dependencies": {
         "@d8a-tech/wt": "^1.2.1",
-        "@walkeros/core": "4.0.2",
-        "@walkeros/web-core": "4.0.2"
+        "@walkeros/core": "4.1.0",
+        "@walkeros/web-core": "4.1.0"
       },
       "devDependencies": {
-        "@walkeros/collector": "4.0.2"
+        "@walkeros/collector": "4.1.0"
       }
     },
     "packages/web/destinations/fullstory": {
@@ -41240,6 +41240,7 @@
         "@walkeros/web-destination-amplitude": "^4.1.0",
         "@walkeros/web-destination-api": "^4.1.0",
         "@walkeros/web-destination-clarity": "^4.1.0",
+        "@walkeros/web-destination-d8a": "^4.1.0",
         "@walkeros/web-destination-fullstory": "^4.1.0",
         "@walkeros/web-destination-gtag": "^4.1.0",
         "@walkeros/web-destination-heap": "^4.1.0",

--- a/packages/cli/src/__tests__/integration/bundle/size-budget.test.ts
+++ b/packages/cli/src/__tests__/integration/bundle/size-budget.test.ts
@@ -6,7 +6,7 @@
  *   2. Dev/zod leakage: the cdn and cdn-skeleton outputs must be free of any
  *      runtime-schema / zod markers that would indicate dev imports snuck in.
  *
- * Baseline: CDN direct IIFE = 50,479 bytes (clean). Budget = baseline × 1.15.
+ * Baseline: CDN direct IIFE = 70,560 bytes (clean). Budget = baseline × 1.15.
  */
 import { readFile, mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
@@ -15,8 +15,11 @@ import { join } from 'path';
 import { bundle } from '../../../commands/bundle/index.js';
 import { MINIMAL_FLOW } from '../../fixtures/minimal-flow.js';
 
-// Budget from Task 0 baseline measurement: 50,479 bytes × 1.15 headroom.
-const SIZE_BUDGET_BYTES = 58051;
+// Clean CDN IIFE baseline (70,560 bytes) × 1.15 headroom. The baseline covers
+// the minimal web flow: core + collector (event engine, mapping, cache,
+// consent, spans) plus the browser source and api destination. This guards
+// against sudden growth; bump it deliberately only when a real feature lands.
+const SIZE_BUDGET_BYTES = 81144;
 
 describe('CDN bundle size budget', () => {
   let tmpDir: string;

--- a/packages/cli/src/__tests__/integration/simulate/prebuilt-bundle.test.ts
+++ b/packages/cli/src/__tests__/integration/simulate/prebuilt-bundle.test.ts
@@ -81,18 +81,18 @@ describe('prebuilt-bundle simulation', () => {
     });
 
     // Core assertions: simulation succeeded
-    expect(result.success).toBe(true);
+    expect(result.step).toBe('destination');
+    expect(result.name).toBe('demo');
     expect(result.duration).toBeGreaterThan(0);
     expect(result.error).toBeUndefined();
+    expect(result.events).toEqual([]);
 
     // The destination-demo dev env tracks calls to env.log via simulation: ['call:log']
-    // Verify that usage was captured (proving __devExports was loaded and wrapEnv worked)
-    expect(result.usage).toBeDefined();
-    expect(result.usage!['demo']).toBeDefined();
-    expect(result.usage!['demo'].length).toBeGreaterThan(0);
+    // Verify that calls were captured (proving __devExports was loaded and wrapEnv worked)
+    expect(result.calls.length).toBeGreaterThan(0);
 
     // Each tracked call should have the expected shape
-    const call = result.usage!['demo'][0];
+    const call = result.calls[0];
     expect(call).toHaveProperty('fn');
     expect(call).toHaveProperty('args');
     expect(call).toHaveProperty('ts');
@@ -111,7 +111,7 @@ describe('prebuilt-bundle simulation', () => {
       silent: true,
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('nonexistent');
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error?.message).toContain('nonexistent');
   }, 60000);
 });

--- a/packages/cli/src/__tests__/unit/validate/contract.test.ts
+++ b/packages/cli/src/__tests__/unit/validate/contract.test.ts
@@ -9,7 +9,7 @@ describe('validateContract', () => {
         consent: { required: ['analytics'] },
       },
       web: {
-        extends: 'default',
+        extend: 'default',
         events: {
           product: {
             add: { properties: { data: { required: ['id'] } } },
@@ -36,26 +36,26 @@ describe('validateContract', () => {
     expect(result.valid).toBe(true);
   });
 
-  it('should report error for extends referencing non-existent contract', () => {
+  it('should report error for extend referencing non-existent contract', () => {
     const result = validateContract({
-      web: { extends: 'nonExistent' },
+      web: { extend: 'nonExistent' },
     });
     expect(result.valid).toBe(false);
     expect(result.errors[0].code).toBe('INVALID_EXTENDS');
   });
 
-  it('should report error for circular extends', () => {
+  it('should report error for circular extend', () => {
     const result = validateContract({
-      a: { extends: 'b' },
-      b: { extends: 'a' },
+      a: { extend: 'b' },
+      b: { extend: 'a' },
     });
     expect(result.valid).toBe(false);
     expect(result.errors[0].code).toBe('CIRCULAR_EXTENDS');
   });
 
-  it('should report error for self-referencing extends', () => {
+  it('should report error for self-referencing extend', () => {
     const result = validateContract({
-      web: { extends: 'web' },
+      web: { extend: 'web' },
     });
     expect(result.valid).toBe(false);
     expect(result.errors[0].code).toBe('CIRCULAR_EXTENDS');
@@ -135,11 +135,11 @@ describe('validateContract', () => {
     expect(result.valid).toBe(true);
   });
 
-  it('should validate deep extends chain', () => {
+  it('should validate deep extend chain', () => {
     const result = validateContract({
       default: { consent: { required: ['analytics'] } },
-      web: { extends: 'default', events: { product: { view: {} } } },
-      web_loggedin: { extends: 'web', user: { required: ['id'] } },
+      web: { extend: 'default', events: { product: { view: {} } } },
+      web_loggedin: { extend: 'web', user: { required: ['id'] } },
     });
     expect(result.valid).toBe(true);
     expect(result.details.contractCount).toBe(3);

--- a/packages/cli/src/commands/push/__tests__/dispatcher-call-shape.test.ts
+++ b/packages/cli/src/commands/push/__tests__/dispatcher-call-shape.test.ts
@@ -17,15 +17,24 @@ const mockedRoutes = jest.mocked(routes);
 
 beforeEach(() => {
   mockedRoutes.simulateDestination.mockReset().mockResolvedValue({
-    success: true,
+    step: 'destination',
+    name: 'mock',
+    events: [],
+    calls: [],
     duration: 0,
   });
   mockedRoutes.simulateSource.mockReset().mockResolvedValue({
-    success: true,
+    step: 'source',
+    name: 'mock',
+    events: [],
+    calls: [],
     duration: 0,
   });
   mockedRoutes.simulateTransformer.mockReset().mockResolvedValue({
-    success: true,
+    step: 'transformer',
+    name: 'mock',
+    events: [],
+    calls: [],
     duration: 0,
   });
   mockedRoutes.push.mockReset().mockResolvedValue({

--- a/packages/cli/src/commands/push/__tests__/simulate-result-shape.test.ts
+++ b/packages/cli/src/commands/push/__tests__/simulate-result-shape.test.ts
@@ -1,0 +1,114 @@
+import type { Flow, WalkerOS } from '@walkeros/core';
+import {
+  simulateSource,
+  simulateTransformer,
+  simulateDestination,
+} from '../index';
+import { buildSimulationResult } from '../simulation-result';
+
+/**
+ * Shape contract for the three simulate functions: each returns a core
+ * `Simulation.Result` ({ step, name, events, calls, duration, error? }).
+ *
+ * The error paths run the real functions end-to-end without needing a built
+ * bundle (they fail before any bundle is loaded), so they directly prove the
+ * return-type contract. The transformer's captured→events mapping (the
+ * load-bearing part of Task 1.3) is asserted through `buildSimulationResult`
+ * with the exact output-only captured entries the function now produces.
+ */
+
+const validEvent: WalkerOS.DeepPartialEvent = {
+  name: 'order complete',
+  entity: 'order',
+  action: 'complete',
+};
+
+// Config object missing the source's `package` → simulateSource throws inside
+// the try block and maps the error into a `Simulation.Result`.
+const sourceConfigNoPackage: Flow.Json = {
+  version: 4,
+  flows: {
+    default: {
+      config: { platform: 'web' },
+      sources: { browser: { config: {} } },
+    },
+  },
+};
+
+describe('simulate functions return Simulation.Result', () => {
+  it('simulateSource error path returns a source-shaped result', async () => {
+    const result = await simulateSource(
+      sourceConfigNoPackage,
+      {},
+      { sourceId: 'browser', silent: true },
+    );
+
+    expect(result.step).toBe('source');
+    expect(result.name).toBe('browser');
+    expect(result.events).toEqual([]);
+    expect(result.calls).toEqual([]);
+    expect(typeof result.duration).toBe('number');
+    expect(result.error).toBeInstanceOf(Error);
+  });
+
+  it('simulateTransformer invalid-event path returns a transformer-shaped result', async () => {
+    const result = await simulateTransformer(
+      { version: 4, flows: {} },
+      // Invalid: `user.email` must be a valid email → Zod rejects before
+      // bundling. This is a valid `DeepPartialEvent` type but fails the
+      // runtime schema, exercising the early-return error path.
+      { user: { email: 'not-an-email' } },
+      { transformerId: 'redact', silent: true },
+    );
+
+    expect(result.step).toBe('transformer');
+    expect(result.name).toBe('redact');
+    expect(result.events).toEqual([]);
+    expect(result.calls).toEqual([]);
+    expect(typeof result.duration).toBe('number');
+    expect(result.error).toBeInstanceOf(Error);
+  });
+
+  it('simulateDestination invalid-event path returns a destination-shaped result', async () => {
+    const result = await simulateDestination(
+      { version: 4, flows: {} },
+      { user: { email: 'not-an-email' } },
+      { destinationId: 'gtag', silent: true },
+    );
+
+    expect(result.step).toBe('destination');
+    expect(result.name).toBe('gtag');
+    expect(result.events).toEqual([]);
+    expect(result.calls).toEqual([]);
+    expect(typeof result.duration).toBe('number');
+    expect(result.error).toBeInstanceOf(Error);
+  });
+});
+
+describe('transformer captured→events mapping (output-only convention)', () => {
+  it('passthrough: a single output event maps to events:[<event>]', () => {
+    const result = buildSimulationResult({
+      step: 'transformer',
+      name: 'enrich',
+      startTime: Date.now(),
+      captured: [{ event: validEvent, timestamp: 0 }],
+    });
+
+    expect(result.step).toBe('transformer');
+    expect(result.events).toEqual([validEvent]);
+    expect(result.calls).toEqual([]);
+  });
+
+  it('drop: a null output entry maps to events:[]', () => {
+    const result = buildSimulationResult({
+      step: 'transformer',
+      name: 'drop',
+      startTime: Date.now(),
+      captured: [{ event: null, timestamp: 0 }],
+    });
+
+    expect(result.step).toBe('transformer');
+    expect(result.events).toEqual([]);
+    expect(result.calls).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/push/__tests__/simulation-result.test.ts
+++ b/packages/cli/src/commands/push/__tests__/simulation-result.test.ts
@@ -1,0 +1,94 @@
+import { buildSimulationResult } from '../simulation-result';
+
+describe('buildSimulationResult', () => {
+  it('maps captured events to events[] and drops null events', () => {
+    const r = buildSimulationResult({
+      step: 'transformer',
+      name: 'redact',
+      startTime: Date.now(),
+      captured: [
+        { event: { name: 'order complete' }, timestamp: 0 },
+        { event: null, timestamp: 1 },
+        { event: undefined, timestamp: 2 },
+      ],
+    });
+    expect(r.step).toBe('transformer');
+    expect(r.name).toBe('redact');
+    expect(r.events).toEqual([{ name: 'order complete' }]);
+    expect(r.calls).toEqual([]);
+    expect(r.error).toBeUndefined();
+    expect(typeof r.duration).toBe('number');
+  });
+
+  it('returns empty events[] when no captured provided', () => {
+    const r = buildSimulationResult({
+      step: 'source',
+      name: 'browser',
+      startTime: Date.now(),
+    });
+    expect(r.events).toEqual([]);
+    expect(r.calls).toEqual([]);
+  });
+
+  it('flattens usage into calls[] for a destination', () => {
+    const r = buildSimulationResult({
+      step: 'destination',
+      name: 'gtag',
+      startTime: Date.now(),
+      usage: {
+        gtag: [{ fn: 'window.gtag', args: ['event', 'purchase'], ts: 5 }],
+      },
+    });
+    expect(r.events).toEqual([]);
+    expect(r.calls).toEqual([
+      { fn: 'window.gtag', args: ['event', 'purchase'], ts: 5 },
+    ]);
+  });
+
+  it('flattens usage across multiple destination keys into one calls[]', () => {
+    const r = buildSimulationResult({
+      step: 'destination',
+      name: 'multi',
+      startTime: Date.now(),
+      usage: {
+        a: [{ fn: 'a.fn', args: [1], ts: 1 }],
+        b: [{ fn: 'b.fn', args: [2], ts: 2 }],
+      },
+    });
+    expect(r.calls).toEqual([
+      { fn: 'a.fn', args: [1], ts: 1 },
+      { fn: 'b.fn', args: [2], ts: 2 },
+    ]);
+  });
+
+  it('wraps non-Error errors into Error', () => {
+    const r = buildSimulationResult({
+      step: 'source',
+      name: 'browser',
+      startTime: Date.now(),
+      error: 'boom',
+    });
+    expect(r.error).toBeInstanceOf(Error);
+    expect(r.error?.message).toBe('boom');
+  });
+
+  it('passes through an existing Error instance unchanged', () => {
+    const err = new Error('explicit');
+    const r = buildSimulationResult({
+      step: 'transformer',
+      name: 'enrich',
+      startTime: Date.now(),
+      error: err,
+    });
+    expect(r.error).toBe(err);
+  });
+
+  it('computes a numeric duration from startTime', () => {
+    const r = buildSimulationResult({
+      step: 'source',
+      name: 'browser',
+      startTime: Date.now() - 5,
+    });
+    expect(r.duration).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/cli/src/commands/push/flow-context.ts
+++ b/packages/cli/src/commands/push/flow-context.ts
@@ -53,10 +53,35 @@ export interface FlowModule {
  * snapshot eval, ESM import with cache bust, error wrapping,
  * global cleanup in finally.
  */
-export async function withFlowContext(
+/**
+ * Default error mapper used by real-push call sites: produces a `PushResult`
+ * error envelope. Simulate call sites override this with a mapper that returns
+ * a `Simulation.Result` instead.
+ */
+function defaultPushError(error: unknown, startTime: number): PushResult {
+  return {
+    success: false,
+    duration: Date.now() - startTime,
+    error: getErrorMessage(error),
+  };
+}
+
+// Real-push call sites: default `PushResult`, no error mapper needed.
+export function withFlowContext(
   options: FlowContextOptions,
   fn: (module: FlowModule) => Promise<PushResult>,
-): Promise<PushResult> {
+): Promise<PushResult>;
+// Simulate call sites: arbitrary result type with an explicit error mapper.
+export function withFlowContext<T>(
+  options: FlowContextOptions,
+  fn: (module: FlowModule) => Promise<T>,
+  onError: (error: unknown, startTime: number) => T,
+): Promise<T>;
+export async function withFlowContext<T>(
+  options: FlowContextOptions,
+  fn: (module: FlowModule) => Promise<T | PushResult>,
+  onError?: (error: unknown, startTime: number) => T,
+): Promise<T | PushResult> {
   const {
     esmPath,
     platform,
@@ -153,7 +178,7 @@ export async function withFlowContext(
       // destinations awaiting an intercepted setTimeout during init don't
       // deadlock (see async-drain-pump.ts for context).
       const stopPump = drainPump ? startDrainPump(timerControl.pending) : null;
-      let result: PushResult;
+      let result: T | PushResult;
       try {
         result = await fn(flowModule);
       } finally {
@@ -173,11 +198,7 @@ export async function withFlowContext(
 
     return await fn(flowModule);
   } catch (error) {
-    return {
-      success: false,
-      duration: Date.now() - startTime,
-      error: getErrorMessage(error),
-    };
+    return (onError ?? defaultPushError)(error, startTime);
   } finally {
     if (timerControl) timerControl.restore();
     if (savedFetch !== undefined) {

--- a/packages/cli/src/commands/push/index.ts
+++ b/packages/cli/src/commands/push/index.ts
@@ -20,7 +20,7 @@ import {
   type Platform,
 } from '../../core/index.js';
 
-import type { Flow, Logger, WalkerOS } from '@walkeros/core';
+import type { Flow, Logger, Simulation, WalkerOS } from '@walkeros/core';
 import { getTmpPath } from '../../core/tmp.js';
 import { loadFlowConfig, loadJsonConfig } from '../../config/index.js';
 import { loadConfig } from '../../config/utils.js';
@@ -30,6 +30,7 @@ import type { PushOptions } from '../../schemas/push.js';
 import { buildOverrides, type PushOverrides } from './overrides.js';
 import { applyOverrides } from './apply-overrides.js';
 import { withFlowContext } from './flow-context.js';
+import { buildSimulationResult } from './simulation-result.js';
 import { prepareFlow } from './prepare.js';
 import { schemas } from '@walkeros/core/dev';
 import { runPushCommand } from './run.js';
@@ -550,7 +551,7 @@ export async function simulateSource(
   configOrPath: string | Flow.Json,
   input: unknown,
   options: SimulateSourceOptions,
-): Promise<PushResult> {
+): Promise<Simulation.Result> {
   const startTime = Date.now();
 
   // Resolve config: accept either file path or config object
@@ -608,7 +609,7 @@ export async function simulateSource(
 
     const networkCalls: NetworkCall[] = [];
 
-    return await withFlowContext(
+    return await withFlowContext<Simulation.Result>(
       {
         esmPath: prepared.bundlePath,
         platform: prepared.platform,
@@ -633,11 +634,17 @@ export async function simulateSource(
 
         // Capture events at the collector.push boundary via prePush hook.
         // Hook is wired by startFlow (inside createTrigger) before events fire.
-        const captured: Array<{ event: unknown; timestamp: number }> = [];
+        const captured: Array<{
+          event: WalkerOS.DeepPartialEvent;
+          timestamp: number;
+        }> = [];
 
         flowConfig.hooks = {
           ...((flowConfig.hooks as Record<string, unknown>) || {}),
-          prePush: ({ fn }: { fn: Function }, event: unknown) => {
+          prePush: (
+            { fn }: { fn: Function },
+            event: WalkerOS.DeepPartialEvent,
+          ) => {
             captured.push({ event, timestamp: Date.now() });
             return { ok: true }; // Stop propagation — don't call fn
           },
@@ -663,20 +670,28 @@ export async function simulateSource(
           await instance.flow.collector.command('shutdown');
         }
 
-        return {
-          success: true,
-          ...(captured.length > 0 ? { captured } : {}),
-          ...(networkCalls.length > 0 ? { networkCalls } : {}),
-          duration: Date.now() - startTime,
-        };
+        return buildSimulationResult({
+          step: 'source',
+          name: options.sourceId,
+          startTime,
+          captured,
+        });
       },
+      (error) =>
+        buildSimulationResult({
+          step: 'source',
+          name: options.sourceId,
+          startTime,
+          error,
+        }),
     );
   } catch (error) {
-    return {
-      success: false,
-      duration: Date.now() - startTime,
-      error: getErrorMessage(error),
-    };
+    return buildSimulationResult({
+      step: 'source',
+      name: options.sourceId,
+      startTime,
+      error,
+    });
   } finally {
     await prepared.cleanup();
   }
@@ -706,17 +721,18 @@ export async function simulateTransformer(
   configOrPath: string | Flow.Json,
   event: WalkerOS.DeepPartialEvent,
   options: SimulateTransformerOptions,
-): Promise<PushResult> {
+): Promise<Simulation.Result> {
   const startTime = Date.now();
 
   // Validate event with Zod
   const parsed = schemas.PartialEventSchema.safeParse(event);
   if (!parsed.success) {
-    return {
-      success: false,
-      duration: 0,
+    return buildSimulationResult({
+      step: 'transformer',
+      name: options.transformerId,
+      startTime,
       error: parsed.error.message,
-    };
+    });
   }
 
   // Resolve config: accept either file path or config object
@@ -767,7 +783,7 @@ export async function simulateTransformer(
 
     const networkCalls: NetworkCall[] = [];
 
-    return await withFlowContext(
+    return await withFlowContext<Simulation.Result>(
       {
         esmPath: prepared.bundlePath,
         platform: prepared.platform,
@@ -810,9 +826,14 @@ export async function simulateTransformer(
 
         const inputEvent = event;
         const ingest = createIngest(options.transformerId);
-        const captured: Array<{ event: unknown; timestamp: number }> = [];
-
-        captured.push({ event: { ...inputEvent }, timestamp: Date.now() });
+        // Output events only: each entry is a transformer output, or `null`
+        // when the event was dropped. `buildSimulationResult` drops null
+        // entries so a drop yields `events: []` and a passthrough yields
+        // `events: [<event>]`.
+        const captured: Array<{
+          event: WalkerOS.DeepPartialEvent | null;
+          timestamp: number;
+        }> = [];
 
         logger.info(`Simulating transformer: ${options.transformerId}`);
 
@@ -839,11 +860,12 @@ export async function simulateTransformer(
             if (beforeResult === null) {
               captured.push({ event: null, timestamp: Date.now() });
               await collector.command('shutdown');
-              return {
-                success: true,
+              return buildSimulationResult({
+                step: 'transformer',
+                name: options.transformerId,
+                startTime,
                 captured,
-                duration: Date.now() - startTime,
-              };
+              });
             }
             processedEvent = (
               Array.isArray(beforeResult) ? beforeResult[0] : beforeResult
@@ -880,20 +902,28 @@ export async function simulateTransformer(
 
         await collector.command('shutdown');
 
-        return {
-          success: true,
+        return buildSimulationResult({
+          step: 'transformer',
+          name: options.transformerId,
+          startTime,
           captured,
-          ...(networkCalls.length > 0 ? { networkCalls } : {}),
-          duration: Date.now() - startTime,
-        };
+        });
       },
+      (error) =>
+        buildSimulationResult({
+          step: 'transformer',
+          name: options.transformerId,
+          startTime,
+          error,
+        }),
     );
   } catch (error) {
-    return {
-      success: false,
-      duration: Date.now() - startTime,
-      error: getErrorMessage(error),
-    };
+    return buildSimulationResult({
+      step: 'transformer',
+      name: options.transformerId,
+      startTime,
+      error,
+    });
   } finally {
     await prepared.cleanup();
   }
@@ -922,17 +952,18 @@ export async function simulateDestination(
   configOrPath: string | Flow.Json,
   event: WalkerOS.DeepPartialEvent,
   options: SimulateDestinationOptions,
-): Promise<PushResult> {
+): Promise<Simulation.Result> {
   const startTime = Date.now();
 
   // Validate event with Zod
   const parsed = schemas.PartialEventSchema.safeParse(event);
   if (!parsed.success) {
-    return {
-      success: false,
-      duration: 0,
+    return buildSimulationResult({
+      step: 'destination',
+      name: options.destinationId,
+      startTime,
       error: parsed.error.message,
-    };
+    });
   }
 
   // Resolve config: accept either file path or config object
@@ -981,7 +1012,7 @@ export async function simulateDestination(
 
     const networkCalls: NetworkCall[] = [];
 
-    return await withFlowContext(
+    return await withFlowContext<Simulation.Result>(
       {
         esmPath: prepared.bundlePath,
         platform: prepared.platform,
@@ -1062,29 +1093,36 @@ export async function simulateDestination(
 
         // Full pipeline: consent, mapping, enrichment, before chains
         // include filter ensures only the target destination receives the event
-        const elbResult = await collector.push(event, {
+        await collector.push(event, {
           include: [options.destinationId],
         });
 
         await collector.command('shutdown');
 
-        return {
-          success: true,
-          elbResult: elbResult as PushResult['elbResult'],
-          ...(trackedCalls.length > 0
-            ? { usage: { [options.destinationId]: trackedCalls } }
-            : {}),
-          ...(networkCalls.length > 0 ? { networkCalls } : {}),
-          duration: Date.now() - startTime,
-        };
+        return buildSimulationResult({
+          step: 'destination',
+          name: options.destinationId,
+          startTime,
+          usage: trackedCalls.length
+            ? { [options.destinationId]: trackedCalls }
+            : undefined,
+        });
       },
+      (error) =>
+        buildSimulationResult({
+          step: 'destination',
+          name: options.destinationId,
+          startTime,
+          error,
+        }),
     );
   } catch (error) {
-    return {
-      success: false,
-      duration: Date.now() - startTime,
-      error: getErrorMessage(error),
-    };
+    return buildSimulationResult({
+      step: 'destination',
+      name: options.destinationId,
+      startTime,
+      error,
+    });
   } finally {
     await prepared.cleanup();
   }

--- a/packages/cli/src/commands/push/run.ts
+++ b/packages/cli/src/commands/push/run.ts
@@ -12,8 +12,23 @@ import {
   type Platform,
 } from '../../core/index.js';
 import { loadJsonFromSource } from '../../config/index.js';
-import type { WalkerOS } from '@walkeros/core';
+import type { Simulation, WalkerOS } from '@walkeros/core';
 import type { PushCommandOptions, PushResult } from './types.js';
+
+/**
+ * Adapt a step `Simulation.Result` into the CLI's `PushResult` envelope. The
+ * `walkeros push --simulate` command path formats and exits on a `PushResult`;
+ * the programmatic simulate functions return the unified `Simulation.Result`.
+ * This boundary keeps the command behavior identical while the functions
+ * expose the richer shape to library consumers.
+ */
+function simulationToPushResult(result: Simulation.Result): PushResult {
+  return {
+    success: !result.error,
+    duration: result.duration,
+    ...(result.error ? { error: result.error.message } : {}),
+  };
+}
 
 /**
  * Pure variant of `pushCommand` — produces a `PushResult` and never calls
@@ -68,27 +83,31 @@ export async function runPushCommand(
         break;
 
       case 'source':
-        result = await simulateSource(config, resolvedEvent, {
-          sourceId: plan.ids[0],
-          flow: options.flow,
-          silent: options.silent,
-          verbose: options.verbose,
-          snapshot: options.snapshot,
-        });
-        break;
-
-      case 'transformer':
-        result = await simulateTransformer(
-          config,
-          resolvedEvent as WalkerOS.DeepPartialEvent,
-          {
-            transformerId: plan.ids[0],
+        result = simulationToPushResult(
+          await simulateSource(config, resolvedEvent, {
+            sourceId: plan.ids[0],
             flow: options.flow,
-            mock: options.mock,
             silent: options.silent,
             verbose: options.verbose,
             snapshot: options.snapshot,
-          },
+          }),
+        );
+        break;
+
+      case 'transformer':
+        result = simulationToPushResult(
+          await simulateTransformer(
+            config,
+            resolvedEvent as WalkerOS.DeepPartialEvent,
+            {
+              transformerId: plan.ids[0],
+              flow: options.flow,
+              mock: options.mock,
+              silent: options.silent,
+              verbose: options.verbose,
+              snapshot: options.snapshot,
+            },
+          ),
         );
         break;
 
@@ -115,8 +134,7 @@ export async function runPushCommand(
 /**
  * Run `simulateDestination` once per destination id and aggregate into a
  * single `PushResult`. Stops on the first failure and returns a structured
- * error referencing the failed id; per-destination results are preserved
- * under `perDestination` for downstream inspection.
+ * error referencing the failed id.
  */
 async function runDestinationSimulationLoop(
   config: string,
@@ -125,7 +143,6 @@ async function runDestinationSimulationLoop(
   options: PushCommandOptions,
 ): Promise<PushResult> {
   const startTime = Date.now();
-  const perDestination: Record<string, PushResult> = {};
 
   for (const destinationId of destinationIds) {
     const r = await simulateDestination(config, event, {
@@ -136,13 +153,11 @@ async function runDestinationSimulationLoop(
       verbose: options.verbose,
       snapshot: options.snapshot,
     });
-    perDestination[destinationId] = r;
-    if (!r.success) {
+    if (r.error) {
       return {
         success: false,
         duration: Date.now() - startTime,
-        error: `simulate destination.${destinationId}: ${r.error ?? 'unknown error'}`,
-        perDestination,
+        error: `simulate destination.${destinationId}: ${r.error.message}`,
       };
     }
   }
@@ -150,6 +165,5 @@ async function runDestinationSimulationLoop(
   return {
     success: true,
     duration: Date.now() - startTime,
-    perDestination,
   };
 }

--- a/packages/cli/src/commands/push/simulation-result.ts
+++ b/packages/cli/src/commands/push/simulation-result.ts
@@ -1,0 +1,71 @@
+import type { Simulation, WalkerOS } from '@walkeros/core';
+import { getErrorMessage } from '../../core/utils.js';
+
+/**
+ * Captured event entry produced by the simulate functions. The event may be
+ * `null`/`undefined` when a transformer drops the event; those entries are
+ * filtered out of the final `events` array.
+ */
+interface CapturedEntry {
+  event: WalkerOS.DeepPartialEvent | null | undefined;
+  timestamp: number;
+}
+
+/** Tracked env call recorded during destination simulation. */
+interface TrackedCall {
+  fn: string;
+  args: unknown[];
+  ts: number;
+}
+
+export interface BuildSimulationResultArgs {
+  step: Simulation.Result['step'];
+  name: string;
+  startTime: number;
+  captured?: CapturedEntry[];
+  usage?: Record<string, TrackedCall[]>;
+  error?: unknown;
+}
+
+/** Type guard that narrows a captured entry to a non-null event. */
+function hasEvent(
+  entry: CapturedEntry,
+): entry is { event: WalkerOS.DeepPartialEvent; timestamp: number } {
+  return entry.event != null;
+}
+
+/** Normalize an unknown error into an `Error` instance. */
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(getErrorMessage(error));
+}
+
+/**
+ * Assemble a core `Simulation.Result` from the raw outputs of the CLI simulate
+ * functions. Pure: maps captured entries to output events (dropping dropped
+ * events), flattens per-destination tracked calls into a single `calls` array,
+ * and computes the elapsed duration.
+ */
+export function buildSimulationResult(
+  args: BuildSimulationResultArgs,
+): Simulation.Result {
+  const { step, name, startTime, captured, usage, error } = args;
+
+  const events: WalkerOS.DeepPartialEvent[] = (captured ?? [])
+    .filter(hasEvent)
+    .map((entry) => entry.event);
+
+  const calls: Simulation.Call[] = usage
+    ? Object.values(usage)
+        .flat()
+        .map((call) => ({ fn: call.fn, args: call.args, ts: call.ts }))
+    : [];
+
+  return {
+    step,
+    name,
+    events,
+    calls,
+    duration: Date.now() - startTime,
+    ...(error !== undefined ? { error: toError(error) } : {}),
+  };
+}

--- a/packages/cli/src/commands/push/types.ts
+++ b/packages/cli/src/commands/push/types.ts
@@ -33,16 +33,8 @@ export interface PushCommandOptions {
 export interface PushResult {
   success: boolean;
   elbResult?: Elb.PushResult;
-  captured?: Array<{ event: unknown; timestamp: number }>;
-  /** Tracked destination API calls keyed by destination ID */
-  usage?: Record<string, Array<{ fn: string; args: unknown[]; ts: number }>>;
   /** Network calls captured during web simulation (fetch + sendBeacon) */
   networkCalls?: NetworkCall[];
-  /**
-   * Per-destination simulation results when --simulate destination.* is
-   * called with multiple ids. Undefined for single-target or non-simulate runs.
-   */
-  perDestination?: Record<string, PushResult>;
   duration: number;
   error?: string;
 }

--- a/packages/cli/src/commands/validate/validators/contract.ts
+++ b/packages/cli/src/commands/validate/validators/contract.ts
@@ -6,7 +6,7 @@ import type {
 
 const SECTION_KEYS = ['globals', 'context', 'custom', 'user', 'consent'];
 const KNOWN_KEYS = new Set([
-  'extends',
+  'extend',
   'description',
   'events',
   ...SECTION_KEYS,
@@ -43,19 +43,19 @@ export function validateContract(input: unknown): ValidateResult {
 
     const obj = entry as Record<string, unknown>;
 
-    // Validate extends
-    if (obj.extends !== undefined) {
-      if (typeof obj.extends !== 'string') {
+    // Validate extend
+    if (obj.extend !== undefined) {
+      if (typeof obj.extend !== 'string') {
         errors.push({
-          path: `${name}.extends`,
-          message: 'extends must be a string',
+          path: `${name}.extend`,
+          message: 'extend must be a string',
           code: 'INVALID_EXTENDS',
         });
-      } else if (!contractNames.includes(obj.extends)) {
+      } else if (!contractNames.includes(obj.extend)) {
         errors.push({
-          path: `${name}.extends`,
-          message: `extends references non-existent contract "${obj.extends}"`,
-          value: obj.extends,
+          path: `${name}.extend`,
+          message: `extend references non-existent contract "${obj.extend}"`,
+          value: obj.extend,
           code: 'INVALID_EXTENDS',
         });
       }
@@ -93,22 +93,22 @@ export function validateContract(input: unknown): ValidateResult {
     }
   }
 
-  // Check for circular extends
+  // Check for circular extend
   for (const name of contractNames) {
     const visited = new Set<string>();
     let current = name;
     while (current) {
       if (visited.has(current)) {
         errors.push({
-          path: `${name}.extends`,
-          message: `Circular extends chain: ${[...visited, current].join(' → ')}`,
+          path: `${name}.extend`,
+          message: `Circular extend chain: ${[...visited, current].join(' → ')}`,
           code: 'CIRCULAR_EXTENDS',
         });
         break;
       }
       visited.add(current);
       const entry = contracts[current] as Record<string, unknown> | undefined;
-      current = (entry?.extends as string) || '';
+      current = (entry?.extend as string) || '';
     }
   }
 

--- a/packages/core/src/__tests__/byPath.test.ts
+++ b/packages/core/src/__tests__/byPath.test.ts
@@ -83,6 +83,29 @@ describe('byPath', () => {
     it('returns the value unchanged when it is not an object', () => {
       expect(deleteByPath<string>('scalar', 'a')).toBe('scalar');
     });
+    it('removes an object field nested inside an array', () => {
+      expect(
+        deleteByPath(
+          { items: [{ id: 'a', secret: 'x' }, { id: 'b' }] },
+          'items.0.secret',
+        ),
+      ).toEqual({ items: [{ id: 'a' }, { id: 'b' }] });
+    });
+    it('splices an array element by index instead of leaving a hole', () => {
+      expect(deleteByPath({ items: ['a', 'b', 'c'] }, 'items.1')).toEqual({
+        items: ['a', 'c'],
+      });
+    });
+    it('is a no-op for an out-of-range array index', () => {
+      expect(deleteByPath({ items: ['a', 'b'] }, 'items.5')).toEqual({
+        items: ['a', 'b'],
+      });
+    });
+    it('is a no-op for a non-numeric segment on an array', () => {
+      expect(deleteByPath({ items: ['a', 'b'] }, 'items.foo')).toEqual({
+        items: ['a', 'b'],
+      });
+    });
   });
 
   describe('getByPath cross-realm', () => {

--- a/packages/core/src/__tests__/byPath.test.ts
+++ b/packages/core/src/__tests__/byPath.test.ts
@@ -1,4 +1,5 @@
 import { createEvent, getByPath, setByPath } from '..';
+import { deleteByPath } from '../byPath';
 
 describe('byPath', () => {
   test('getByPath', () => {
@@ -63,6 +64,25 @@ describe('byPath', () => {
     // Modified event should have the new field
     expect(modifiedEvent.data).toHaveProperty('newField', 'newValue');
     expect(modifiedEvent).not.toBe(originalEvent);
+  });
+
+  describe('deleteByPath', () => {
+    it('removes a top-level key, returning a new object', () => {
+      const input = { a: 1, b: 2 };
+      expect(deleteByPath(input, 'b')).toEqual({ a: 1 });
+      expect(input).toEqual({ a: 1, b: 2 });
+    });
+    it('removes a nested key via dotted path', () => {
+      expect(
+        deleteByPath({ data: { id: 1, currency: 'EUR' } }, 'data.currency'),
+      ).toEqual({ data: { id: 1 } });
+    });
+    it('is a no-op when the path does not exist', () => {
+      expect(deleteByPath({ a: 1 }, 'b.c')).toEqual({ a: 1 });
+    });
+    it('returns the value unchanged when it is not an object', () => {
+      expect(deleteByPath<string>('scalar', 'a')).toBe('scalar');
+    });
   });
 
   describe('getByPath cross-realm', () => {

--- a/packages/core/src/__tests__/contract.test.ts
+++ b/packages/core/src/__tests__/contract.test.ts
@@ -46,7 +46,7 @@ describe('mergeContractSchemas', () => {
 });
 
 describe('resolveContracts', () => {
-  it('should resolve a single contract with no extends', () => {
+  it('should resolve a single contract with no extend', () => {
     const contract: Flow.Contract = {
       default: {
         schema: {
@@ -70,7 +70,7 @@ describe('resolveContracts', () => {
     expect(resolved.default.events?.product.view).toBeDefined();
   });
 
-  it('should resolve extends chain', () => {
+  it('should resolve extend chain', () => {
     const contract: Flow.Contract = {
       default: {
         schema: {
@@ -82,7 +82,7 @@ describe('resolveContracts', () => {
         },
       },
       web: {
-        extends: 'default',
+        extend: 'default',
         events: {
           product: { view: {} },
         },
@@ -100,7 +100,7 @@ describe('resolveContracts', () => {
     expect(resolved.web.events?.product.view).toBeDefined();
   });
 
-  it('should resolve deep extends chain', () => {
+  it('should resolve deep extend chain', () => {
     const contract: Flow.Contract = {
       default: {
         schema: {
@@ -111,11 +111,11 @@ describe('resolveContracts', () => {
         },
       },
       web: {
-        extends: 'default',
+        extend: 'default',
         events: { product: { view: {} } },
       },
       web_loggedin: {
-        extends: 'web',
+        extend: 'web',
         schema: {
           type: 'object',
           properties: {
@@ -135,24 +135,24 @@ describe('resolveContracts', () => {
     expect(resolved.web_loggedin.events?.product.view).toBeDefined();
   });
 
-  it('should detect circular extends', () => {
+  it('should detect circular extend', () => {
     const contract: Flow.Contract = {
-      a: { extends: 'b' },
-      b: { extends: 'a' },
+      a: { extend: 'b' },
+      b: { extend: 'a' },
     };
     expect(() => resolveContracts(contract)).toThrow(/circular/i);
   });
 
-  it('should detect self-referencing extends', () => {
+  it('should detect self-referencing extend', () => {
     const contract: Flow.Contract = {
-      web: { extends: 'web' },
+      web: { extend: 'web' },
     };
     expect(() => resolveContracts(contract)).toThrow(/circular/i);
   });
 
-  it('should throw for extends referencing non-existent contract', () => {
+  it('should throw for extend referencing non-existent contract', () => {
     const contract: Flow.Contract = {
-      web: { extends: 'nonExistent' },
+      web: { extend: 'nonExistent' },
     };
     expect(() => resolveContracts(contract)).toThrow(/nonExistent/);
   });
@@ -199,7 +199,7 @@ describe('resolveContracts', () => {
     });
   });
 
-  it('should resolve extends before wildcards', () => {
+  it('should resolve extend before wildcards', () => {
     const contract: Flow.Contract = {
       default: {
         events: {
@@ -209,7 +209,7 @@ describe('resolveContracts', () => {
         },
       },
       web: {
-        extends: 'default',
+        extend: 'default',
         events: {
           product: {
             add: { properties: { data: { required: ['qty'] } } },
@@ -234,7 +234,7 @@ describe('resolveContracts', () => {
         },
       },
       web: {
-        extends: 'default',
+        extend: 'default',
       },
     };
     const resolved = resolveContracts(contract);
@@ -244,17 +244,17 @@ describe('resolveContracts', () => {
   it('should let child tagging override parent tagging', () => {
     const contract: Flow.Contract = {
       default: { tagging: 1 },
-      web: { extends: 'default', tagging: 2 },
+      web: { extend: 'default', tagging: 2 },
     };
     const resolved = resolveContracts(contract);
     expect(resolved.web.tagging).toBe(2);
   });
 
-  it('should propagate tagging through a multi-level extends chain', () => {
+  it('should propagate tagging through a multi-level extend chain', () => {
     const contract: Flow.Contract = {
       default: { tagging: 3 },
-      web: { extends: 'default' },
-      web_loggedin: { extends: 'web' },
+      web: { extend: 'default' },
+      web_loggedin: { extend: 'web' },
     };
     const resolved = resolveContracts(contract);
     expect(resolved.web.tagging).toBe(3);
@@ -329,7 +329,7 @@ describe('resolveContracts', () => {
     });
   });
 
-  it('merges schemas additively via extends', () => {
+  it('merges schemas additively via extend', () => {
     const contract: Flow.Contract = {
       default: {
         schema: {
@@ -338,7 +338,7 @@ describe('resolveContracts', () => {
         },
       },
       web: {
-        extends: 'default',
+        extend: 'default',
         schema: {
           type: 'object',
           properties: { consent: { required: ['analytics'] } },
@@ -353,7 +353,7 @@ describe('resolveContracts', () => {
     });
   });
 
-  it('unions required arrays via extends', () => {
+  it('unions required arrays via extend', () => {
     const contract: Flow.Contract = {
       default: {
         schema: {
@@ -362,7 +362,7 @@ describe('resolveContracts', () => {
         },
       },
       web: {
-        extends: 'default',
+        extend: 'default',
         schema: {
           type: 'object',
           properties: { globals: { type: 'object', required: ['currency'] } },

--- a/packages/core/src/__tests__/flow.test.ts
+++ b/packages/core/src/__tests__/flow.test.ts
@@ -115,6 +115,31 @@ describe('Flow Schemas', () => {
       expect(() => SourceSchema.parse({})).not.toThrow();
     });
 
+    test('accepts import alongside package', () => {
+      expect(() =>
+        SourceSchema.parse({
+          package: '@walkeros/web-source-browser',
+          import: 'sourceBrowser',
+        }),
+      ).not.toThrow();
+    });
+
+    test('rejects import without package', () => {
+      expect(() => SourceSchema.parse({ import: 'sourceBrowser' })).toThrow(
+        '`import` requires `package`',
+      );
+    });
+
+    test('rejects import combined with inline code', () => {
+      expect(() =>
+        SourceSchema.parse({
+          package: '@walkeros/web-source-browser',
+          import: 'sourceBrowser',
+          code: { push: '$code:() => {}' },
+        }),
+      ).toThrow('`import` cannot be combined with inline `code`');
+    });
+
     test('accepts inline code object', () => {
       const validSource = {
         code: {

--- a/packages/core/src/__tests__/flow.test.ts
+++ b/packages/core/src/__tests__/flow.test.ts
@@ -2160,7 +2160,7 @@ describe('$contract reference resolution', () => {
     });
   });
 
-  test('resolves extends before path resolution', () => {
+  test('resolves extend before path resolution', () => {
     const setup: Flow.Json = {
       version: 4,
       contract: {
@@ -2170,7 +2170,7 @@ describe('$contract reference resolution', () => {
             properties: { consent: { required: ['analytics'] } },
           },
         },
-        web: { extends: 'default', events: { product: { view: {} } } },
+        web: { extend: 'default', events: { product: { view: {} } } },
       },
       flows: {
         default: {

--- a/packages/core/src/__tests__/mapping.test.ts
+++ b/packages/core/src/__tests__/mapping.test.ts
@@ -990,4 +990,30 @@ describe('processEventMapping', () => {
       expect(result.silent).toBe(true);
     });
   });
+
+  test('remove strips paths from produced data after evaluation', async () => {
+    const event = {
+      name: 'order complete',
+      data: { total: 42, currency: 'EUR' },
+    };
+    const config = {
+      mapping: {
+        order: {
+          complete: {
+            data: {
+              map: {
+                value: 'data.total',
+                currency: 'data.currency',
+              },
+            },
+            remove: ['currency'],
+          },
+        },
+      },
+    };
+
+    const result = await processEventMapping(event, config, mockCollector);
+
+    expect(result.data).toEqual({ value: 42 });
+  });
 });

--- a/packages/core/src/__tests__/merge-config-schema.test.ts
+++ b/packages/core/src/__tests__/merge-config-schema.test.ts
@@ -1,4 +1,4 @@
-import { mergeConfigSchema } from '../merge-config-schema';
+import { mergeConfigSchema, resolveBaseSchema } from '../merge-config-schema';
 
 /**
  * Structural shape of the merged JSON Schema returned by `mergeConfigSchema`.
@@ -139,5 +139,29 @@ describe('mergeConfigSchema', () => {
     expect(props?.ingest).toBeUndefined();
     expect(props?.queue).toBeUndefined();
     expect(props?.consent).toBeUndefined();
+  });
+});
+
+describe('resolveBaseSchema (exported unwrap)', () => {
+  it('unwraps allOf/$ref + definitions one level so properties is reachable', () => {
+    const wrapped = {
+      description: 'X',
+      allOf: [{ $ref: '#/definitions/Foo' }],
+      definitions: {
+        Foo: { type: 'object', properties: { a: { type: 'string' } } },
+      },
+    };
+    const resolved = resolveBaseSchema(wrapped);
+    expect(resolved?.properties).toEqual({ a: { type: 'string' } });
+    expect(resolved?.definitions).toHaveProperty('Foo');
+  });
+
+  it('returns the schema unchanged when properties already present', () => {
+    const flat = { type: 'object', properties: { a: { type: 'string' } } };
+    expect(resolveBaseSchema(flat)).toBe(flat);
+  });
+
+  it('returns undefined for undefined input', () => {
+    expect(resolveBaseSchema(undefined)).toBeUndefined();
   });
 });

--- a/packages/core/src/__tests__/mergeMapping.test.ts
+++ b/packages/core/src/__tests__/mergeMapping.test.ts
@@ -1,0 +1,86 @@
+import { mergeMappingRule } from '../mergeMapping';
+import type { Mapping } from '../types';
+
+describe('mergeMappingRule', () => {
+  const base: Mapping.Rule = {
+    name: 'order complete',
+    data: {
+      map: {
+        id: 'params.ep.transaction_id',
+        currency: 'params.ep.currency',
+        total: 'params.epn.value',
+      },
+    },
+    consent: { marketing: true },
+  };
+  it('replaces when neither extend nor remove is present', () => {
+    expect(mergeMappingRule(base, { name: 'purchase' })).toEqual({
+      name: 'purchase',
+    });
+  });
+  it('adds a new data.map field, inheriting the rest', () => {
+    const result = mergeMappingRule(base, {
+      extend: { data: { map: { coupon: 'params.ep.coupon' } } },
+    });
+    expect(result.data).toEqual({
+      map: {
+        id: 'params.ep.transaction_id',
+        currency: 'params.ep.currency',
+        total: 'params.epn.value',
+        coupon: 'params.ep.coupon',
+      },
+    });
+    expect(result.name).toBe('order complete');
+  });
+  it('overrides a single data.map field, leaving siblings intact', () => {
+    const result = mergeMappingRule(base, {
+      extend: { data: { map: { id: 'params.ep.order_id' } } },
+    });
+    expect(result.data).toEqual({
+      map: {
+        id: 'params.ep.order_id',
+        currency: 'params.ep.currency',
+        total: 'params.epn.value',
+      },
+    });
+  });
+  it('overrides the event name while inheriting data', () => {
+    const result = mergeMappingRule(base, { extend: { name: 'purchase' } });
+    expect(result.name).toBe('purchase');
+    expect(result.data).toEqual(base.data);
+  });
+  it('clears an inherited field when extend sets it to null', () => {
+    const result = mergeMappingRule(base, { extend: { consent: null } });
+    expect('consent' in result).toBe(false);
+  });
+  it('carries remove onto the merged rule', () => {
+    const result = mergeMappingRule(base, { remove: ['currency'] });
+    expect(result.remove).toEqual(['currency']);
+    expect(result.data).toEqual(base.data);
+  });
+  it('combines extend and remove', () => {
+    const result = mergeMappingRule(base, {
+      extend: { data: { map: { coupon: 'params.ep.coupon' } } },
+      remove: ['currency'],
+    });
+    expect(result.data).toEqual({
+      map: {
+        id: 'params.ep.transaction_id',
+        currency: 'params.ep.currency',
+        total: 'params.epn.value',
+        coupon: 'params.ep.coupon',
+      },
+    });
+    expect(result.remove).toEqual(['currency']);
+  });
+  it('does not mutate base or override', () => {
+    mergeMappingRule(base, { extend: { data: { map: { coupon: 'x' } } } });
+    expect(base.data).toEqual({
+      map: {
+        id: 'params.ep.transaction_id',
+        currency: 'params.ep.currency',
+        total: 'params.epn.value',
+      },
+    });
+  });
+});

--- a/packages/core/src/__tests__/schemas/contract.test.ts
+++ b/packages/core/src/__tests__/schemas/contract.test.ts
@@ -22,7 +22,7 @@ describe('Contract schema validation', () => {
           },
         },
         web: {
-          extends: 'default',
+          extend: 'default',
           consent: { required: ['analytics'] },
         },
       },

--- a/packages/core/src/__tests__/schemas/mapping.test.ts
+++ b/packages/core/src/__tests__/schemas/mapping.test.ts
@@ -1,0 +1,23 @@
+import { RuleSchema } from '../../schemas/mapping';
+describe('RuleSchema extend/remove', () => {
+  it('preserves extend with a nested partial rule', () => {
+    expect(
+      RuleSchema.parse({
+        extend: { data: { map: { affiliation: 'params.ep.affiliation' } } },
+      }).extend,
+    ).toEqual({ data: { map: { affiliation: 'params.ep.affiliation' } } });
+  });
+  it('preserves a null value in extend (clear an inherited field)', () => {
+    expect(RuleSchema.parse({ extend: { consent: null } }).extend).toEqual({
+      consent: null,
+    });
+  });
+  it('preserves remove as a string array', () => {
+    expect(
+      RuleSchema.parse({ remove: ['currency', 'data.tax'] }).remove,
+    ).toEqual(['currency', 'data.tax']);
+  });
+  it('rejects remove that is not a string array', () => {
+    expect(RuleSchema.safeParse({ remove: [1, 2] }).success).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/types/contract.test.ts
+++ b/packages/core/src/__tests__/types/contract.test.ts
@@ -36,7 +36,7 @@ describe('Contract types', () => {
           },
         },
         web: {
-          extends: 'default',
+          extend: 'default',
           schema: {
             type: 'object',
             properties: {
@@ -55,12 +55,12 @@ describe('Contract types', () => {
     expect(setup.contract).toBeDefined();
   });
 
-  it('should accept contract with extends chain', () => {
+  it('should accept contract with extend chain', () => {
     const contract: Flow.Contract = {
       default: { description: 'base' },
-      web: { extends: 'default', events: { product: { view: {} } } },
+      web: { extend: 'default', events: { product: { view: {} } } },
       web_loggedin: {
-        extends: 'web',
+        extend: 'web',
         schema: {
           type: 'object',
           properties: {

--- a/packages/core/src/byPath.ts
+++ b/packages/core/src/byPath.ts
@@ -86,3 +86,25 @@ export function setByPath<T = unknown>(obj: T, key: string, value: unknown): T {
 
   return clonedObj as T;
 }
+
+/**
+ * Deletes a value in an object by a dot-notation string.
+ * Returns a new object; the input is not mutated. No-op when the
+ * path is absent or the target is not an object.
+ */
+export function deleteByPath<T = unknown>(obj: T, key: string): T {
+  if (!isObject(obj)) return obj;
+  const clonedObj = clone(obj);
+  const keys = key.split('.');
+  let current: WalkerOS.AnyObject = clonedObj;
+  for (let i = 0; i < keys.length; i++) {
+    const k = keys[i] as keyof typeof current;
+    if (i === keys.length - 1) {
+      delete current[k];
+    } else {
+      if (!isObject(current[k])) return clonedObj;
+      current = current[k] as WalkerOS.AnyObject;
+    }
+  }
+  return clonedObj as T;
+}

--- a/packages/core/src/byPath.ts
+++ b/packages/core/src/byPath.ts
@@ -89,21 +89,37 @@ export function setByPath<T = unknown>(obj: T, key: string, value: unknown): T {
 
 /**
  * Deletes a value in an object by a dot-notation string.
- * Returns a new object; the input is not mutated. No-op when the
- * path is absent or the target is not an object.
+ * Returns a new object; the input is not mutated. No-op when the path is
+ * absent or the target is neither an object nor an array. Numeric segments
+ * index into arrays; a final numeric segment splices the element out so no
+ * empty slot is left behind.
  */
 export function deleteByPath<T = unknown>(obj: T, key: string): T {
-  if (!isObject(obj)) return obj;
+  if (!isObject(obj) && !isArray(obj)) return obj;
   const clonedObj = clone(obj);
   const keys = key.split('.');
-  let current: WalkerOS.AnyObject = clonedObj;
+  let current: WalkerOS.AnyObject | unknown[] = clonedObj;
   for (let i = 0; i < keys.length; i++) {
-    const k = keys[i] as keyof typeof current;
-    if (i === keys.length - 1) {
+    const k = keys[i];
+    const isLast = i === keys.length - 1;
+
+    if (isArray(current)) {
+      const index = Number(k);
+      if (!Number.isInteger(index) || index < 0 || index >= current.length)
+        return clonedObj;
+      if (isLast) {
+        current.splice(index, 1);
+      } else {
+        const next = current[index];
+        if (!isObject(next) && !isArray(next)) return clonedObj;
+        current = next;
+      }
+    } else if (isLast) {
       delete current[k];
     } else {
-      if (!isObject(current[k])) return clonedObj;
-      current = current[k] as WalkerOS.AnyObject;
+      const next = current[k];
+      if (!isObject(next) && !isArray(next)) return clonedObj;
+      current = next;
     }
   }
   return clonedObj as T;

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -10,7 +10,7 @@ const ANNOTATION_KEYS = new Set([
 ]);
 
 /**
- * Resolve all named contracts: process extends chains, expand wildcards,
+ * Resolve all named contracts: process extend chains, expand wildcards,
  * strip annotations from event schemas.
  *
  * Returns a fully resolved map where each contract entry has inherited
@@ -27,7 +27,7 @@ export function resolveContracts(
 
     if (resolving.has(name)) {
       throwError(
-        `Circular extends chain detected: ${[...resolving, name].join(' → ')}`,
+        `Circular extend chain detected: ${[...resolving, name].join(' → ')}`,
       );
     }
 
@@ -40,16 +40,16 @@ export function resolveContracts(
 
     let result: Flow.ContractRule = {};
 
-    // 1. Resolve parent first (if extends)
-    if (entry.extends) {
-      const parent = resolve(entry.extends);
+    // 1. Resolve parent first (if extend)
+    if (entry.extend) {
+      const parent = resolve(entry.extend);
       result = mergeContractEntries(parent, entry);
     } else {
       result = { ...entry };
     }
 
-    // Remove extends from resolved entry
-    delete result.extends;
+    // Remove extend from resolved entry
+    delete result.extend;
 
     // 2. Expand wildcards in events
     if (result.events) {

--- a/packages/core/src/dev.ts
+++ b/packages/core/src/dev.ts
@@ -1,7 +1,7 @@
 export * as schemas from './schemas';
 export { z, zodToSchema, type JSONSchema } from './schemas';
 export { ClickIdEntrySchema } from './schemas';
-export { mergeConfigSchema } from './merge-config-schema';
+export { mergeConfigSchema, resolveBaseSchema } from './merge-config-schema';
 
 export { formatOut } from './examples/formatOut';
 export type { Flow } from './types/flow';

--- a/packages/core/src/flow.ts
+++ b/packages/core/src/flow.ts
@@ -522,7 +522,7 @@ function resolveFlowSettings(
   // Deep clone to avoid mutations
   const result = JSON.parse(JSON.stringify(settings)) as Flow;
 
-  // Pre-process contracts: resolve $var/$env inside contracts, then extends + wildcards
+  // Pre-process contracts: resolve $var/$env inside contracts, then extend + wildcards
   let resolvedContracts: Record<string, Flow.ContractRule> | undefined;
   if (config.contract) {
     // Two-pass: resolve $var/$env inside contract first

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export * from './invocations';
 export * from './is';
 export * from './logger';
 export * from './mapping';
+export * from './mergeMapping';
 export * from './mockEnv';
 export * from './mockContext';
 export * from './mockLogger';

--- a/packages/core/src/mapping.ts
+++ b/packages/core/src/mapping.ts
@@ -1,5 +1,5 @@
 import type { Mapping, WalkerOS, Collector } from './types';
-import { getByPath, setByPath } from './byPath';
+import { deleteByPath, getByPath, setByPath } from './byPath';
 import { isArray, isDefined, isString, isObject } from './is';
 import { castToProperty } from './property';
 import { tryCatchAsync } from './tryCatch';
@@ -367,6 +367,14 @@ export async function processEventMapping<
             data as Record<string, unknown>,
           ) as unknown as WalkerOS.Property)
         : (data ?? (includeData as unknown as WalkerOS.Property));
+    }
+  }
+
+  // Output layer: strip removed paths from the produced data. Applied last,
+  // after include, so remove always wins. Rooted at the produced payload.
+  if (eventMapping?.remove && isObject(data)) {
+    for (const path of eventMapping.remove) {
+      data = deleteByPath(data, path);
     }
   }
 

--- a/packages/core/src/merge-config-schema.ts
+++ b/packages/core/src/merge-config-schema.ts
@@ -59,7 +59,7 @@ export function mergeConfigSchema(
  *   - Draft-2020 form: `{ $ref: '#/$defs/X', $defs: {...} }`
  * Unwrap one level if needed so callers can mutate `properties` directly.
  */
-function resolveBaseSchema(
+export function resolveBaseSchema(
   baseSchema: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
   if (!baseSchema) return baseSchema;

--- a/packages/core/src/mergeMapping.ts
+++ b/packages/core/src/mergeMapping.ts
@@ -1,0 +1,49 @@
+import type { Mapping } from './types';
+import { isObject } from './is';
+import { clone } from './clone';
+
+function mergePatch(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  for (const key of Object.keys(source)) {
+    const val = source[key];
+    if (val === undefined) continue;
+    if (val === null) {
+      delete target[key];
+      continue;
+    }
+    const cur = target[key];
+    if (isObject(val) && isObject(cur)) {
+      mergePatch(cur, val);
+    } else {
+      target[key] = val;
+    }
+  }
+  return target;
+}
+
+/**
+ * Resolve a user mapping rule against a package-shipped default rule.
+ * - No extend/remove → replace (clone of override; today's behavior).
+ * - extend → partial rule deep-merged onto base (null clears a field).
+ * - remove → carried onto the merged rule for eval-time output stripping.
+ * The returned rule never contains `extend`.
+ */
+export function mergeMappingRule(
+  base: Mapping.Rule,
+  override: Mapping.Rule,
+): Mapping.Rule {
+  if (override.extend === undefined && override.remove === undefined) {
+    return clone(override);
+  }
+  const merged: Record<string, unknown> = { ...clone(base) };
+  if (override.extend) {
+    const patch: Record<string, unknown> = { ...override.extend };
+    mergePatch(merged, patch);
+  }
+  delete merged.extend;
+  if (override.remove) merged.remove = [...override.remove];
+  else delete merged.remove;
+  return merged as Mapping.Rule;
+}

--- a/packages/core/src/schemas/flow.ts
+++ b/packages/core/src/schemas/flow.ts
@@ -628,7 +628,7 @@ export const ContractEventsSchema = z
  */
 export const ContractRuleSchema = z
   .object({
-    extends: z.string().optional(),
+    extend: z.string().optional(),
     tagging: z.number().optional(),
     description: z.string().optional(),
     events: ValidateEventsSchema.optional(),
@@ -648,9 +648,9 @@ export const ContractSchema = z
   .meta({
     id: 'FlowContract',
     title: 'Flow.Contract',
-    description: 'Named contracts map with optional extends inheritance.',
+    description: 'Named contracts map with optional extend inheritance.',
   })
-  .describe('Named contracts with optional extends inheritance');
+  .describe('Named contracts with optional extend inheritance');
 
 // ========================================
 // Per-flow Config block + Single Flow
@@ -783,7 +783,7 @@ export const JsonSchema = z
       'Shared variables for interpolation across all flows (use $var.name syntax, deep paths supported)',
     ),
     contract: ContractSchema.optional().describe(
-      'Named contracts with extends inheritance and dot-path references',
+      'Named contracts with extend inheritance and dot-path references',
     ),
     flows: z
       .record(z.string(), FlowSchema)

--- a/packages/core/src/schemas/flow.ts
+++ b/packages/core/src/schemas/flow.ts
@@ -280,6 +280,32 @@ export const ValidateSchema = z
 // ========================================
 
 /**
+ * Cross-field rules shared by every step (source / destination / transformer /
+ * store): `import` names an export from `package`, so it requires `package` and
+ * cannot be combined with inline `code`. Enforced here because these are
+ * relationships between fields that a flat object schema cannot express on its
+ * own, so without it an invalid step would pass validation and fail at resolve.
+ */
+function checkImportCode(
+  value: { package?: string; code?: unknown; import?: string },
+  ctx: z.RefinementCtx,
+): void {
+  if (value.import === undefined) return;
+  if (value.code !== undefined)
+    ctx.addIssue({
+      code: 'custom',
+      message: '`import` cannot be combined with inline `code`',
+      path: ['import'],
+    });
+  if (value.package === undefined)
+    ctx.addIssue({
+      code: 'custom',
+      message: '`import` requires `package`',
+      path: ['import'],
+    });
+}
+
+/**
  * Source reference schema (Flow.Source).
  *
  * @remarks
@@ -364,7 +390,8 @@ export const SourceSchema = z
     description:
       'Source package reference with configuration, env, chains, and examples.',
   })
-  .describe('Source package reference with configuration');
+  .describe('Source package reference with configuration')
+  .superRefine(checkImportCode);
 
 /**
  * Transformer reference schema (Flow.Transformer).
@@ -432,7 +459,8 @@ export const TransformerSchema = z
     description:
       'Transformer package reference with configuration, env, chains, and cache.',
   })
-  .describe('Transformer package reference with configuration');
+  .describe('Transformer package reference with configuration')
+  .superRefine(checkImportCode);
 
 /**
  * Destination reference schema (Flow.Destination).
@@ -507,7 +535,8 @@ export const DestinationSchema = z
     description:
       'Destination package reference with configuration, env, chains, and cache.',
   })
-  .describe('Destination package reference with configuration');
+  .describe('Destination package reference with configuration')
+  .superRefine(checkImportCode);
 
 /**
  * Store reference schema (Flow.Store).
@@ -577,7 +606,8 @@ export const StoreSchema = z
     description:
       'Store package reference with configuration, env, cache, and examples.',
   })
-  .describe('Store package reference with configuration');
+  .describe('Store package reference with configuration')
+  .superRefine(checkImportCode);
 
 // ========================================
 // Contract Schemas

--- a/packages/core/src/schemas/mapping.ts
+++ b/packages/core/src/schemas/mapping.ts
@@ -231,6 +231,37 @@ export const PolicySchema = z
 // Mapping Rule Schemas
 // ========================================
 
+export const RulePatchSchema = z
+  .object({
+    name: z.string().nullable().optional(),
+    data: z.union([ValueSchema, ValuesSchema]).nullable().optional(),
+    settings: z.any().optional(),
+    condition: z.string().nullable().optional(),
+    consent: ConsentSchema.nullable().optional(),
+    policy: PolicySchema.nullable().optional(),
+    batch: z
+      .union([
+        z.number(),
+        z.object({
+          wait: z.number().optional(),
+          size: z.number().optional(),
+          age: z.number().optional(),
+        }),
+      ])
+      .nullable()
+      .optional(),
+    include: z.array(z.string()).nullable().optional(),
+    ignore: z.boolean().nullable().optional(),
+    silent: z.boolean().nullable().optional(),
+  })
+  .meta({
+    id: 'MappingRulePatch',
+    title: 'Mapping.RulePatch',
+    description:
+      'Partial rule deep-merged onto a package-shipped default; a null value clears the inherited field.',
+  })
+  .describe('Partial rule for `extend`; null clears an inherited field');
+
 /**
  * Rule - Event-specific mapping configuration
  *
@@ -300,6 +331,15 @@ export const RuleSchema = z
       .optional()
       .describe(
         'Run side effects (settings.identify, ...) but suppress the destination default push call.',
+      ),
+    extend: RulePatchSchema.optional().describe(
+      'Merge mode: a partial rule deep-merged onto the package-shipped default at this key (instead of replacing it). A null value clears an inherited field.',
+    ),
+    remove: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Dotted paths stripped from the produced data payload after evaluation (applied last).',
       ),
   })
   .meta({

--- a/packages/core/src/schemas/mapping.ts
+++ b/packages/core/src/schemas/mapping.ts
@@ -235,7 +235,7 @@ export const RulePatchSchema = z
   .object({
     name: z.string().nullable().optional(),
     data: z.union([ValueSchema, ValuesSchema]).nullable().optional(),
-    settings: z.any().optional(),
+    settings: z.unknown().nullable().optional(),
     condition: z.string().nullable().optional(),
     consent: ConsentSchema.nullable().optional(),
     policy: PolicySchema.nullable().optional(),
@@ -288,7 +288,7 @@ export const RuleSchema = z
       .optional()
       .describe('Data transformation rules for event'),
     settings: z
-      .any()
+      .unknown()
       .optional()
       .describe('Destination-specific settings for this event mapping'),
     condition: z

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -626,8 +626,8 @@ export namespace Flow {
    * ```json
    * {
    *   "default": { "globals": { ... }, "consent": { ... } },
-   *   "web": { "extends": "default", "events": { ... } },
-   *   "server": { "extends": "default", "events": { ... } }
+   *   "web": { "extend": "default", "events": { ... } },
+   *   "server": { "extend": "default", "events": { ... } }
    * }
    * ```
    */
@@ -640,11 +640,11 @@ export namespace Flow {
    * globals, context, custom, user, consent.
    * Entity-action schemas live under `events`.
    *
-   * Use `extends` to inherit from another named contract (additive merge).
+   * Use `extend` to inherit from another named contract (additive merge).
    */
   export interface ContractRule {
     /** Inherit from another named contract entry. */
-    extends?: string;
+    extend?: string;
     /** Contract revision marker. */
     tagging?: number;
     /** Human-readable note. */

--- a/packages/core/src/types/mapping.ts
+++ b/packages/core/src/types/mapping.ts
@@ -57,10 +57,16 @@ export interface Rule<Settings = unknown> {
 
 /**
  * A partial Rule used by `Rule.extend`. Every field is optional, and a
- * `null` value clears the inherited field (JSON merge-patch delete).
+ * `null` value clears the inherited field (JSON merge-patch delete). The
+ * control fields `extend` and `remove` are excluded: a patch models only
+ * direct rule fields, matching what the runtime patch schema accepts.
  */
+type RulePatchFields<Settings = unknown> = Omit<
+  Rule<Settings>,
+  'extend' | 'remove'
+>;
 export type RulePatch<Settings = unknown> = {
-  [K in keyof Rule<Settings>]?: Rule<Settings>[K] | null;
+  [K in keyof RulePatchFields<Settings>]?: RulePatchFields<Settings>[K] | null;
 };
 
 export interface Result {

--- a/packages/core/src/types/mapping.ts
+++ b/packages/core/src/types/mapping.ts
@@ -39,7 +39,29 @@ export interface Rule<Settings = unknown> {
   silent?: boolean; // Process settings side effects, but suppress the destination's default push call
   name?: string; // Use a custom event name
   policy?: Policy; // Event-level policy applied after config-level policy
+  /**
+   * Merge mode (config layer): a partial Rule deep-merged onto the
+   * package-shipped default rule at the same key, instead of replacing it.
+   * Resolved at the consuming package's init via `mergeMappingRule`; not
+   * seen by the runtime evaluator. A `null` value clears an inherited field.
+   * Presence of `extend` or `remove` switches this rule from replace to merge.
+   */
+  extend?: RulePatch<Settings>;
+  /**
+   * Output layer: dotted paths stripped from the produced data payload
+   * after evaluation, regardless of how each field was produced. Applied
+   * last, so it always wins.
+   */
+  remove?: string[];
 }
+
+/**
+ * A partial Rule used by `Rule.extend`. Every field is optional, and a
+ * `null` value clears the inherited field (JSON merge-patch delete).
+ */
+export type RulePatch<Settings = unknown> = {
+  [K in keyof Rule<Settings>]?: Rule<Settings>[K] | null;
+};
 
 export interface Result {
   eventMapping?: Rule;

--- a/packages/mcps/mcp/src/__tests__/tools/simulate.test.ts
+++ b/packages/mcps/mcp/src/__tests__/tools/simulate.test.ts
@@ -98,13 +98,12 @@ describe('flow_simulate tool', () => {
     expect(config.outputSchema).toBe(SimulateOutputShape);
   });
 
-  it('summarizes per-destination results', async () => {
+  it('summarizes a destination result keyed by result name', async () => {
     mockSimulateDestination.mockResolvedValue({
-      success: true,
-      usage: {
-        gtag: [{ fn: 'event', args: ['page_view'], ts: 1 }],
-        meta: [],
-      },
+      step: 'destination',
+      name: 'gtag',
+      events: [],
+      calls: [{ fn: 'window.gtag', args: ['event', 'page_view'], ts: 1 }],
       duration: 42,
     });
 
@@ -118,29 +117,27 @@ describe('flow_simulate tool', () => {
 
     expect(result.structuredContent.success).toBe(true);
     expect(result.structuredContent.summary).toBe(
-      '1/2 destinations received the event',
+      '1/1 destinations received the event',
     );
     expect(result.structuredContent.destinations.gtag.received).toBe(true);
     expect(result.structuredContent.destinations.gtag.calls).toBe(1);
-    expect(result.structuredContent.destinations.meta.received).toBe(false);
-    expect(result.structuredContent.destinations.meta.calls).toBe(0);
     expect(result.structuredContent.duration).toBe(42);
     expect(result.isError).toBeUndefined();
   });
 
   it('returns all calls in payload when verbose', async () => {
     mockSimulateDestination.mockResolvedValue({
-      success: true,
-      usage: {
-        gtag: [
-          { fn: 'window.gtag', args: ['config', 'G-TEST123', {}], ts: 1 },
-          {
-            fn: 'window.gtag',
-            args: ['event', 'purchase', { value: 99, currency: 'EUR' }],
-            ts: 2,
-          },
-        ],
-      },
+      step: 'destination',
+      name: 'gtag',
+      events: [],
+      calls: [
+        { fn: 'window.gtag', args: ['config', 'G-TEST123', {}], ts: 1 },
+        {
+          fn: 'window.gtag',
+          args: ['event', 'purchase', { value: 99, currency: 'EUR' }],
+          ts: 2,
+        },
+      ],
       duration: 50,
     });
 
@@ -167,10 +164,10 @@ describe('flow_simulate tool', () => {
 
   it('omits payload when not verbose', async () => {
     mockSimulateDestination.mockResolvedValue({
-      success: true,
-      usage: {
-        gtag: [{ fn: 'window.gtag', args: ['event', 'page_view'], ts: 1 }],
-      },
+      step: 'destination',
+      name: 'gtag',
+      events: [],
+      calls: [{ fn: 'window.gtag', args: ['event', 'page_view'], ts: 1 }],
       duration: 10,
     });
 
@@ -189,8 +186,10 @@ describe('flow_simulate tool', () => {
 
   it('passes parameters to simulateDestination with destinationId', async () => {
     mockSimulateDestination.mockResolvedValue({
-      success: true,
-      usage: {},
+      step: 'destination',
+      name: 'ga4',
+      events: [],
+      calls: [],
       duration: 10,
     });
 
@@ -278,13 +277,10 @@ describe('flow_simulate tool', () => {
 
   it('returns capturedEvents for source simulation', async () => {
     mockSimulateSource.mockResolvedValue({
-      success: true,
-      captured: [
-        {
-          event: { name: 'cta click', data: { label: 'Sign Up' } },
-          timestamp: 1,
-        },
-      ],
+      step: 'source',
+      name: 'browser',
+      events: [{ name: 'cta click', data: { label: 'Sign Up' } }],
+      calls: [],
       duration: 15,
     });
 
@@ -321,7 +317,10 @@ describe('flow_simulate tool', () => {
 
   it('calls simulateTransformer for transformer step', async () => {
     mockSimulateTransformer.mockResolvedValue({
-      success: true,
+      step: 'transformer',
+      name: 'demo',
+      events: [{ name: 'page view', data: { title: 'Home' } }],
+      calls: [],
       duration: 8,
     });
 
@@ -338,6 +337,7 @@ describe('flow_simulate tool', () => {
     expect(result.structuredContent.summary).toBe(
       'Transformer processed event',
     );
+    expect(result.structuredContent.capturedEvents).toHaveLength(1);
 
     expect(mockSimulateTransformer).toHaveBeenCalledWith(
       './flow.json',
@@ -350,9 +350,12 @@ describe('flow_simulate tool', () => {
     );
   });
 
-  it('handles simulation with no usage data', async () => {
+  it('reports received: false when destination makes no calls', async () => {
     mockSimulateDestination.mockResolvedValue({
-      success: true,
+      step: 'destination',
+      name: 'gtag',
+      events: [],
+      calls: [],
       duration: 10,
     });
 
@@ -366,15 +369,18 @@ describe('flow_simulate tool', () => {
 
     expect(result.structuredContent.success).toBe(true);
     expect(result.structuredContent.summary).toBe(
-      '0/0 destinations received the event',
+      '0/1 destinations received the event',
     );
-    expect(result.structuredContent.destinations).toBeUndefined();
+    expect(result.structuredContent.destinations.gtag.received).toBe(false);
+    expect(result.structuredContent.destinations.gtag.calls).toBe(0);
   });
 
-  it('warns when destination step yields 0 destinations', async () => {
+  it('warns when destination receives no calls', async () => {
     mockSimulateDestination.mockResolvedValue({
-      success: true,
-      usage: {},
+      step: 'destination',
+      name: 'gtag',
+      events: [],
+      calls: [],
       duration: 5,
     });
 
@@ -388,31 +394,6 @@ describe('flow_simulate tool', () => {
 
     expect(result.structuredContent._hints?.warnings).toBeDefined();
     expect(result.structuredContent._hints.warnings.length).toBeGreaterThan(0);
-  });
-
-  it('does not warn when destinations exist but none received event', async () => {
-    mockSimulateDestination.mockResolvedValue({
-      success: true,
-      usage: {
-        gtag: [],
-        meta: [],
-      },
-      duration: 5,
-    });
-
-    const tool = server.getTool('flow_simulate');
-    const result = await tool.handler({
-      configPath: './flow.json',
-      event: '{"name":"page view"}',
-      flow: undefined,
-      step: 'destination.gtag',
-    });
-
-    // Warning only fires when destCount === 0, not when destinations exist but are empty
-    expect(result.structuredContent.summary).toBe(
-      '0/2 destinations received the event',
-    );
-    expect(result.structuredContent._hints?.warnings).toBeUndefined();
   });
 
   it('handles non-Error exceptions', async () => {
@@ -431,15 +412,14 @@ describe('flow_simulate tool', () => {
     expect(parsed.error).toBe('Unknown error');
   });
 
-  it('uses elbResult.done as fallback when no usage data', async () => {
+  it('surfaces step error message from result.error', async () => {
     mockSimulateDestination.mockResolvedValue({
-      success: true,
-      elbResult: {
-        done: {
-          gtag: { id: '123' },
-        },
-      } as any,
+      step: 'destination',
+      name: 'gtag',
+      events: [],
+      calls: [],
       duration: 20,
+      error: new Error('mapping threw'),
     });
 
     const tool = server.getTool('flow_simulate');
@@ -450,12 +430,8 @@ describe('flow_simulate tool', () => {
       step: 'destination.gtag',
     });
 
-    expect(result.structuredContent.success).toBe(true);
-    expect(result.structuredContent.summary).toBe(
-      '1/1 destinations received the event',
-    );
-    expect(result.structuredContent.destinations.gtag.received).toBe(true);
-    expect(result.structuredContent.destinations.gtag.calls).toBe(0);
+    expect(result.structuredContent.success).toBe(false);
+    expect(result.structuredContent.error).toBe('mapping threw');
   });
 
   it('errors on invalid step format without dot separator', async () => {

--- a/packages/mcps/mcp/src/tools/simulate.ts
+++ b/packages/mcps/mcp/src/tools/simulate.ts
@@ -4,10 +4,10 @@ import {
   simulateTransformer,
   simulateDestination,
 } from '@walkeros/cli';
-import type { PushResult } from '@walkeros/cli';
 import { schemas } from '@walkeros/cli/dev';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { mcpResult, mcpError } from '@walkeros/core';
+import type { Simulation, WalkerOS } from '@walkeros/core';
 import { SimulateOutputShape } from '../schemas/output.js';
 
 import type { ToolSpec } from '../tool-spec.js';
@@ -116,7 +116,7 @@ async function flowSimulateHandlerBody(input: unknown) {
     const stepType = step.substring(0, dotIndex);
     const stepId = step.substring(dotIndex + 1);
 
-    let result: PushResult;
+    let result: Simulation.Result;
 
     switch (stepType) {
       case 'source':
@@ -130,7 +130,7 @@ async function flowSimulateHandlerBody(input: unknown) {
       case 'transformer':
         result = await simulateTransformer(
           configPath,
-          resolvedEvent as import('@walkeros/core').WalkerOS.DeepPartialEvent,
+          resolvedEvent as WalkerOS.DeepPartialEvent,
           {
             transformerId: stepId,
             flow,
@@ -142,7 +142,7 @@ async function flowSimulateHandlerBody(input: unknown) {
       case 'destination':
         result = await simulateDestination(
           configPath,
-          resolvedEvent as import('@walkeros/core').WalkerOS.DeepPartialEvent,
+          resolvedEvent as WalkerOS.DeepPartialEvent,
           {
             destinationId: stepId,
             flow,
@@ -157,17 +157,20 @@ async function flowSimulateHandlerBody(input: unknown) {
         );
     }
 
-    // Source simulation returns captured events
-    if (result.captured && result.captured.length > 0) {
-      const eventCount = result.captured.length;
+    const success = !result.error;
+    const errorMessage = result.error?.message;
+
+    // Source simulation: captured events are result.events
+    if (result.step === 'source') {
+      const eventCount = result.events.length;
       const summary = `Source captured ${eventCount} event${eventCount !== 1 ? 's' : ''}`;
 
       return mcpResult(
         {
-          success: result.success,
-          error: result.error,
+          success,
+          error: errorMessage,
           summary,
-          capturedEvents: result.captured,
+          capturedEvents: result.events,
           duration: result.duration,
         },
         {
@@ -183,35 +186,33 @@ async function flowSimulateHandlerBody(input: unknown) {
       );
     }
 
-    // Destination/transformer simulation
+    // Transformer simulation: surface the transformed events
+    if (result.step === 'transformer') {
+      return mcpResult(
+        {
+          success,
+          error: errorMessage,
+          summary: `Transformer processed event`,
+          capturedEvents: result.events,
+          duration: result.duration,
+        },
+        {
+          next: ['Use flow_bundle to build for production'],
+        },
+      );
+    }
+
+    // Destination simulation: count intercepted env calls, key by step name
     const destinations: Record<string, DestinationSummary> = {};
-
-    // Build destinations summary from elbResult.done
-    if (
-      result.elbResult &&
-      typeof result.elbResult === 'object' &&
-      'done' in result.elbResult &&
-      result.elbResult.done
-    ) {
-      const done = result.elbResult.done as Record<string, unknown>;
-      for (const name of Object.keys(done)) {
-        destinations[name] = { received: true, calls: 0 };
-      }
+    const callCount = result.calls.length;
+    const destSummary: DestinationSummary = {
+      received: callCount > 0,
+      calls: callCount,
+    };
+    if (verbose && callCount > 0) {
+      destSummary.payload = result.calls;
     }
-
-    // Also check usage (call tracking from mock envs)
-    if (result.usage) {
-      for (const [name, calls] of Object.entries(result.usage)) {
-        const summary: DestinationSummary = {
-          received: calls.length > 0,
-          calls: calls.length,
-        };
-        if (verbose && calls.length > 0) {
-          summary.payload = calls;
-        }
-        destinations[name] = summary;
-      }
-    }
+    destinations[result.name] = destSummary;
 
     const destCount = Object.keys(destinations).length;
     const receivedCount = Object.values(destinations).filter(
@@ -219,7 +220,7 @@ async function flowSimulateHandlerBody(input: unknown) {
     ).length;
 
     const warnings: string[] = [];
-    if (stepType === 'destination' && destCount === 0) {
+    if (receivedCount === 0) {
       warnings.push(
         'Destination did not receive the event. Common causes: ' +
           '(1) destination config has consent: { marketing: true } but event lacks matching consent, ' +
@@ -229,16 +230,11 @@ async function flowSimulateHandlerBody(input: unknown) {
       );
     }
 
-    const summary =
-      stepType === 'transformer'
-        ? `Transformer processed event`
-        : `${receivedCount}/${destCount} destinations received the event`;
-
     const resultObj = {
-      success: result.success,
-      error: result.error,
-      summary,
-      destinations: destCount > 0 ? destinations : undefined,
+      success,
+      error: errorMessage,
+      summary: `${receivedCount}/${destCount} destinations received the event`,
+      destinations,
       duration: result.duration,
     };
 

--- a/packages/server/destinations/meta/src/__tests__/index.test.ts
+++ b/packages/server/destinations/meta/src/__tests__/index.test.ts
@@ -106,6 +106,30 @@ describe('Server Destination Meta', () => {
     expect(requestBody.test_event_code).toEqual('TEST');
   });
 
+  test('access token sent in Authorization header, not URL', async () => {
+    const event = getEvent();
+    const config: Config = {
+      settings: { accessToken, pixelId },
+    };
+
+    await destination.push(
+      event,
+      createMockContext({
+        config,
+        env: testEnv,
+        id: 'test-meta',
+      }),
+    );
+
+    expect(mockSendServer).toHaveBeenCalled();
+    const url = mockSendServer.mock.calls[0][0];
+    const options = mockSendServer.mock.calls[0][2];
+
+    expect(url).not.toContain('access_token');
+    expect(url).not.toContain(accessToken);
+    expect(options.headers.Authorization).toBe(`Bearer ${accessToken}`);
+  });
+
   test('environment customization', async () => {
     const customSendServer = jest.fn();
     customSendServer.mockResolvedValue({ ok: true, data: {} });

--- a/packages/server/destinations/meta/src/examples/step.ts
+++ b/packages/server/destinations/meta/src/examples/step.ts
@@ -4,17 +4,19 @@ import { getEvent, isObject } from '@walkeros/core';
 /**
  * Meta Conversions API step examples.
  *
- * At push time, the destination calls `env.sendServer(url, body)` where
- * `url` is `${settings.url}${settings.pixelId}/events?access_token=${settings.accessToken}`
- * and `body` is the JSON-stringified `{ data: [serverEvent] }` payload.
+ * At push time, the destination calls `env.sendServer(url, body, options)`
+ * where `url` is `${settings.url}${settings.pixelId}/events`, `body` is the
+ * JSON-stringified `{ data: [serverEvent] }` payload, and `options` carries the
+ * access token in an `Authorization: Bearer` header (never in the URL).
  *
  * The public name users see when inspecting the destination is `sendServer`,
- * so each `out` tuple is `['sendServer', url, body]` with `body` as the
- * already-stringified JSON payload (mirroring the actual call signature).
+ * so each `out` tuple is `['sendServer', url, body, options]` with `body` as
+ * the already-stringified JSON payload (mirroring the actual call signature).
  *
  * The test fixture pins `accessToken = 's3cr3t'` and `pixelId = 'p1x3l1d'`,
  * so every endpoint resolves to:
- *   https://graph.facebook.com/v22.0/p1x3l1d/events?access_token=s3cr3t
+ *   https://graph.facebook.com/v22.0/p1x3l1d/events
+ * with header `Authorization: Bearer s3cr3t`.
  *
  * Body fields are emitted in the order the destination constructs them
  * (insertion order matters for `JSON.stringify` string equality):
@@ -26,8 +28,9 @@ import { getEvent, isObject } from '@walkeros/core';
  *   6. user_data (hashed per Meta's PII requirements)
  *   7. event_source_url (appended after hash when action_source === 'website')
  */
-const ENDPOINT =
-  'https://graph.facebook.com/v22.0/p1x3l1d/events?access_token=s3cr3t';
+const ENDPOINT = 'https://graph.facebook.com/v22.0/p1x3l1d/events';
+
+const OPTIONS = { headers: { Authorization: 'Bearer s3cr3t' } };
 
 export const purchase: Flow.StepExample = {
   title: 'Purchase',
@@ -98,6 +101,7 @@ export const purchase: Flow.StepExample = {
           },
         ],
       }),
+      OPTIONS,
     ],
   ],
 };
@@ -134,6 +138,7 @@ export const lead: Flow.StepExample = {
           },
         ],
       }),
+      OPTIONS,
     ],
   ],
 };
@@ -196,6 +201,7 @@ export const purchaseWithClickAttribution: Flow.StepExample = {
           },
         ],
       }),
+      OPTIONS,
     ],
   ],
 };

--- a/packages/server/destinations/meta/src/push.ts
+++ b/packages/server/destinations/meta/src/push.ts
@@ -78,10 +78,11 @@ export const push: PushFn = async function (
   });
 
   const sendServerFn = env?.sendServer || sendServer;
-  const result = await sendServerFn(
-    `${endpoint}?access_token=${accessToken}`,
-    JSON.stringify(body),
-  );
+  const result = await sendServerFn(endpoint, JSON.stringify(body), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
 
   logger.debug('Meta API response', {
     ok: isObject(result) ? result.ok : true,

--- a/packages/transformers/ga4/src/__tests__/transformer.test.ts
+++ b/packages/transformers/ga4/src/__tests__/transformer.test.ts
@@ -282,4 +282,51 @@ describe('transformerGa4', () => {
       expect(logger.error).not.toHaveBeenCalled();
     });
   });
+
+  describe('mapping extend/remove', () => {
+    it('extend adds a new data.map field while inheriting the default fields', async () => {
+      const ctx = makeContext({
+        settings: {
+          mapping: {
+            purchase: {
+              extend: {
+                data: { map: { affiliation: 'params.ep.affiliation' } },
+              },
+            },
+          },
+        },
+        url: 'https://x/g/collect?v=2&tid=G-X&en=purchase&ep.transaction_id=T-1&epn.value=10&ep.currency=EUR&ep.affiliation=partner-1',
+      });
+      const instance = await transformerGa4(ctx);
+      const result = await instance.push(emptyEvent, ctx);
+      expect(result).toEqual({
+        event: expect.objectContaining({
+          data: expect.objectContaining({
+            id: 'T-1',
+            currency: 'EUR',
+            total: 10,
+            affiliation: 'partner-1',
+          }),
+        }),
+      });
+    });
+
+    it('remove strips a field from the produced data', async () => {
+      const ctx = makeContext({
+        settings: {
+          mapping: { purchase: { remove: ['currency'] } },
+        },
+        url: 'https://x/g/collect?v=2&tid=G-X&en=purchase&ep.transaction_id=T-1&epn.value=10&ep.currency=EUR',
+      });
+      const instance = await transformerGa4(ctx);
+      const result = await instance.push(emptyEvent, ctx);
+      expect(result).toEqual({
+        event: expect.objectContaining({
+          data: expect.objectContaining({ id: 'T-1', total: 10 }),
+        }),
+      });
+      const event = (result as { event: WalkerOS.DeepPartialEvent }).event;
+      expect(event.data).not.toHaveProperty('currency');
+    });
+  });
 });

--- a/packages/transformers/ga4/src/map.ts
+++ b/packages/transformers/ga4/src/map.ts
@@ -1,5 +1,5 @@
 import type { Mapping, WalkerOS } from '@walkeros/core';
-import { getByPath, getId } from '@walkeros/core';
+import { getByPath, getId, deleteByPath, isObject } from '@walkeros/core';
 import type {
   GA4Event,
   GA4Hit,
@@ -77,7 +77,10 @@ function mapOneEvent(
   }
 
   if (rule.data !== undefined) {
-    const data = evalValue(rule.data, lookup);
+    let data = evalValue(rule.data, lookup);
+    if (rule.remove && isObject(data)) {
+      for (const path of rule.remove) data = deleteByPath(data, path);
+    }
     if (data !== undefined) {
       evaluated.data = data as WalkerOS.Properties;
     }

--- a/packages/transformers/ga4/src/merge.ts
+++ b/packages/transformers/ga4/src/merge.ts
@@ -1,0 +1,24 @@
+import { mergeMappingRule } from '@walkeros/core';
+import type { GA4Mapping } from './types';
+
+/**
+ * Merge user mapping overrides onto the shipped defaults, per GA4 event key.
+ * A user entry with `extend`/`remove` patches the default; otherwise it
+ * replaces it. `GA4Mapping` values are single rules (no Rule[]), matching
+ * the evaluator. `extend` only changes anything for keys that ship a default.
+ */
+export function mergeGa4Mapping(
+  defaults: GA4Mapping,
+  user: GA4Mapping,
+): GA4Mapping {
+  const merged: GA4Mapping = { ...defaults };
+  for (const key of Object.keys(user)) {
+    const userRule = user[key];
+    if (!userRule) continue;
+    const baseRule = defaults[key];
+    merged[key] = baseRule
+      ? mergeMappingRule(baseRule, userRule)
+      : mergeMappingRule({}, userRule);
+  }
+  return merged;
+}

--- a/packages/transformers/ga4/src/transformer.ts
+++ b/packages/transformers/ga4/src/transformer.ts
@@ -2,6 +2,7 @@ import type { Ingest, Transformer } from '@walkeros/core';
 import { parseRequest } from './parse';
 import { mapHitToEvents } from './map';
 import { defaultMapping } from './defaults';
+import { mergeGa4Mapping } from './merge';
 import type { GA4Request, GA4Settings } from './types';
 
 /**
@@ -32,7 +33,7 @@ export const transformerGa4: Transformer.Init<
   const { config } = context;
   const settings = config.settings ?? {};
   const tidPattern = new RegExp(settings.tidPattern ?? '^G-');
-  const mapping = { ...defaultMapping, ...(settings.mapping ?? {}) };
+  const mapping = mergeGa4Mapping(defaultMapping, settings.mapping ?? {});
 
   return {
     type: 'ga4',

--- a/packages/web/destinations/d8a/package.json
+++ b/packages/web/destinations/d8a/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walkeros/web-destination-d8a",
   "description": "d8a web destination for walkerOS",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -38,11 +38,11 @@
   },
   "dependencies": {
     "@d8a-tech/wt": "^1.2.1",
-    "@walkeros/core": "4.0.2",
-    "@walkeros/web-core": "4.0.2"
+    "@walkeros/core": "4.1.0",
+    "@walkeros/web-core": "4.1.0"
   },
   "devDependencies": {
-    "@walkeros/collector": "4.0.2"
+    "@walkeros/collector": "4.1.0"
   },
   "repository": {
     "url": "git+https://github.com/elbwalker/walkerOS.git",

--- a/skills/walkeros-mapping-configuration/SKILL.md
+++ b/skills/walkeros-mapping-configuration/SKILL.md
@@ -14,15 +14,18 @@ for core concepts.
 
 ## Quick Reference
 
-| I want to...         | Use this pattern                                      |
-| -------------------- | ----------------------------------------------------- |
-| Rename event         | `{ name: 'new_name' }`                                |
-| Extract nested value | `'data.nested.value'`                                 |
-| Set static value     | `{ value: 'USD' }`                                    |
-| Transform value      | `{ fn: (e) => transform(e) }`                         |
-| Build object         | `{ map: { key: 'source' } }`                          |
-| Process array        | `{ loop: ['source', { map: {...} }] }`                |
-| Gate by consent      | `{ key: 'data.email', consent: { marketing: true } }` |
+| I want to...                   | Use this pattern                                      |
+| ------------------------------ | ----------------------------------------------------- |
+| Rename event                   | `{ name: 'new_name' }`                                |
+| Extract nested value           | `'data.nested.value'`                                 |
+| Set static value               | `{ value: 'USD' }`                                    |
+| Transform value                | `{ fn: (e) => transform(e) }`                         |
+| Build object                   | `{ map: { key: 'source' } }`                          |
+| Process array                  | `{ loop: ['source', { map: {...} }] }`                |
+| Gate by consent                | `{ key: 'data.email', consent: { marketing: true } }` |
+| First defined value (fallback) | `[{ key: 'data.sku' }, { key: 'data.id' }]`           |
+| Add a field to a default rule  | `{ extend: { data: { map: { x: 'path' } } } }`        |
+| Drop a field from output       | `{ remove: ['field.path'] }`                          |
 
 ## Common Recipes
 
@@ -182,6 +185,55 @@ order: {
   ],
 }
 ```
+
+### Patching Package-Shipped Rules (`extend` / `remove`)
+
+Some packages (such as `@walkeros/transformer-ga4`) ship default mapping rules.
+Normally a user rule at the same key replaces the default in full. Use `extend`
+or `remove` to patch instead.
+
+Two layers, two keywords:
+
+- **`extend`** runs at init (config layer): deep-merges a partial rule onto the
+  shipped default. A `null` value clears an inherited field.
+- **`remove`** runs after evaluation (output layer): strips dotted paths from
+  the final data payload. Applied last, always wins.
+
+A rule with neither keyword keeps the existing replace behavior.
+
+```json
+{
+  "purchase": {
+    "extend": {
+      "data": { "map": { "affiliation": "params.ep.affiliation" } }
+    },
+    "remove": ["currency"]
+  }
+}
+```
+
+This keeps all fields the package ships for `purchase`, adds `affiliation`, and
+strips `currency` from the output.
+
+For the full reference and the two-layer model, see
+[Mapping.Rule docs](/docs/mapping/rule#patching-package-shipped-rules).
+
+### Value[] Fallback Chains
+
+At any value position, an array of values is a fallback chain: the first entry
+that resolves to a defined value wins.
+
+```json
+{
+  "item_id": [
+    { "key": "data.sku" },
+    { "key": "data.id" },
+    { "value": "unknown" }
+  ]
+}
+```
+
+Use this to try multiple source fields before falling back to a constant.
 
 ### Consent-Gated Fields
 

--- a/skills/walkeros-understanding-mapping/SKILL.md
+++ b/skills/walkeros-understanding-mapping/SKILL.md
@@ -98,6 +98,38 @@ interface Rule {
   consent?: Consent; // Required consent for this rule
   settings?: unknown; // Custom event configuration
   batch?: number; // Batch size for grouping
+  extend?: RulePatch; // Config-layer merge onto a package-shipped default rule
+  remove?: string[]; // Output-layer: dotted paths stripped from the final payload
+}
+```
+
+#### `extend` and `remove` (patching package-shipped rules)
+
+Some packages ship their own default mapping rules. A user rule at the same key
+normally replaces the default in full. Two keywords change that:
+
+- **`extend`** (config layer): a partial rule deep-merged onto the
+  package-shipped default at init, before any event is evaluated. A `null` value
+  clears an inherited field. Lets you add or override one field while keeping
+  the rest.
+- **`remove`** (output layer): dotted paths stripped from the produced payload
+  after evaluation, applied last. Useful for dropping PII or vendor-reserved
+  fields without rewriting the full rule.
+
+A rule with **neither** keyword keeps the standard replace behavior.
+
+See the
+[website mapping docs](/docs/mapping/rule#patching-package-shipped-rules) for
+the authoritative reference and the GA4 example.
+
+```json
+{
+  "purchase": {
+    "extend": {
+      "data": { "map": { "affiliation": "params.ep.affiliation" } }
+    },
+    "remove": ["currency"]
+  }
 }
 ```
 
@@ -225,7 +257,7 @@ Common patterns shown below. For detailed examples of all 12 strategies, see
 // Set (create array)
 { set: ['data.id'] }                      // → ["SKU-123"]
 
-// Fallback array (first success wins)
+// Fallback chain: Value[] at any value position (first defined value wins)
 [{ key: 'data.sku' }, { key: 'data.id' }, { value: 'unknown' }]
 
 // Consent-gated
@@ -395,17 +427,19 @@ TypeScript ignores the unused second arg.
 
 ### Rule Features Cheatsheet
 
-| Feature     | Purpose                                            |
-| ----------- | -------------------------------------------------- |
-| `name`      | Override event name                                |
-| `data`      | Transform event data                               |
-| `ignore`    | Skip event entirely (no processing, no push)       |
-| `silent`    | Run settings side effects, skip default forwarding |
-| `policy`    | Pre-process event                                  |
-| `condition` | Match condition (arrays)                           |
-| `consent`   | Required consent                                   |
-| `settings`  | Custom configuration                               |
-| `batch`     | Batch size                                         |
+| Feature     | Purpose                                                                 |
+| ----------- | ----------------------------------------------------------------------- |
+| `name`      | Override event name                                                     |
+| `data`      | Transform event data                                                    |
+| `ignore`    | Skip event entirely (no processing, no push)                            |
+| `silent`    | Run settings side effects, skip default forwarding                      |
+| `policy`    | Pre-process event                                                       |
+| `condition` | Match condition (arrays)                                                |
+| `consent`   | Required consent                                                        |
+| `settings`  | Custom configuration                                                    |
+| `batch`     | Batch size                                                              |
+| `extend`    | Config-layer merge onto a package-shipped default (null clears a field) |
+| `remove`    | Output-layer: dotted paths stripped from the final payload              |
 
 ### Config Features Cheatsheet
 

--- a/skills/walkeros-using-cli/commands-reference.md
+++ b/skills/walkeros-using-cli/commands-reference.md
@@ -354,7 +354,7 @@ Default: validates input as Flow.Json (schema, references, cross-step examples).
 | `flow` (default) | Flow.Json    | Schema, references, cross-step examples |
 | `event`          | Event object | Name format, schema, consent            |
 | `mapping`        | Mapping      | Pattern format, rule structure          |
-| `contract`       | Contract     | Named entries, extends, sections        |
+| `contract`       | Contract     | Named entries, extend, sections         |
 
 Use `--path` for entry validation against package schemas:
 

--- a/skills/walkeros-using-transformer-ga4/SKILL.md
+++ b/skills/walkeros-using-transformer-ga4/SKILL.md
@@ -4,7 +4,8 @@ description:
   Use when wiring `@walkeros/transformer-ga4` into a server flow, overriding
   default GA4 event mappings, dropping events, adding custom event keys, or
   troubleshooting GA4 Measurement Protocol decoding. Covers the `before`-chain
-  wiring contract, configuration recipes, and v1 limitations.
+  wiring contract, configuration recipes, and per-field patching with
+  extend/remove.
 ---
 
 # Using `@walkeros/transformer-ga4`
@@ -17,9 +18,8 @@ source's `before` chain, reads the raw HTTP request via `ctx.ingest`, and
 returns one walkerOS event per GA4 event in the hit (one hit can carry many
 events).
 
-This is the v1 release at `0.1.0`. Boundaries are explicit: server-side decoding
-via `source-express`, GA4 v2 only, replace-not-merge mapping semantics, `G-`
-tids only by default.
+Boundaries: server-side decoding via `source-express`, GA4 v2 only, `G-` tids
+only by default. Per-field patching via `extend`/`remove` is supported.
 
 ## When to use this skill
 
@@ -73,10 +73,13 @@ tids only by default.
 
 ## Configuration recipes
 
-### Override one field in a default mapping
+### Patch one field in a default mapping (extend + remove)
 
-User config **replaces** the matching default rule. Copy any fields you want to
-keep:
+Use `extend` to add or override individual fields of a shipped default rule
+without replacing it in full. Use `remove` to strip fields from the output.
+
+The `purchase` default ships `id`, `currency`, `total`, `tax`, `shipping`, and
+`coupon`. To add `affiliation` from a GA4 event parameter and drop `currency`:
 
 ```json
 "transformers": {
@@ -86,15 +89,10 @@ keep:
       "settings": {
         "mapping": {
           "purchase": {
-            "name": "order complete",
-            "data": {
-              "map": {
-                "id": "params.ep.transaction_id",
-                "total": "params.epn.value",
-                "currency": "params.ep.currency",
-                "coupon": "params.ep.promo_code"
-              }
-            }
+            "extend": {
+              "data": { "map": { "affiliation": "params.ep.affiliation" } }
+            },
+            "remove": ["currency"]
           }
         }
       }
@@ -103,8 +101,32 @@ keep:
 }
 ```
 
-There is no additive per-field merge in v1. Replace the full rule, or leave it
-alone.
+`extend.data.map` is deep-merged onto the default `data.map`, leaving `id`,
+`total`, `tax`, `shipping`, and `coupon` intact. `remove: ["currency"]` strips
+that field from the final payload. A `null` value in `extend` clears an
+inherited field entirely (e.g. `"extend": { "name": null }`).
+
+**Full replace:** if you need to rewrite a rule from scratch (no merge), omit
+`extend` and `remove` and supply the complete rule directly. A rule with neither
+keyword keeps the existing replace behavior.
+
+```json
+"settings": {
+  "mapping": {
+    "purchase": {
+      "name": "order complete",
+      "data": {
+        "map": {
+          "id": "params.ep.transaction_id",
+          "total": "params.epn.value",
+          "currency": "params.ep.currency",
+          "coupon": "params.ep.promo_code"
+        }
+      }
+    }
+  }
+}
+```
 
 ### Drop an event
 
@@ -206,8 +228,8 @@ the `params` namespace.
 1. Check the path syntax: `params.ep.X`, not `ep.X`.
 2. Verify the GA4 hit actually carries the parameter. Use a debug destination to
    log the decoded `params` object.
-3. Remember replace semantics: if you override an event, your `data.map` is the
-   entire rule. Missing fields stay missing.
+3. If you used a full-replace rule (no `extend`), your `data.map` is the entire
+   rule. Use `extend` to inherit the defaults and add only the fields you need.
 
 ### Batched POST drops events after the first
 
@@ -221,14 +243,13 @@ v1 decodes basic `gcs` (`G1XX` → `marketing` / `analytics` booleans) only.
 Functional/preferences flags and the newer `gcd` parameter are not decoded.
 Override the consent path manually if you need richer mapping.
 
-## Limitations of v1
+## Limitations
 
-- **Replace semantics only.** No per-field additive merge inside `data.map`.
 - **GA4 v2 only.** v1 Measurement Protocol is out of scope.
 - **`G-` tids only by default.** Override `tidPattern` for Ads/DC.
 - **Basic `gcs` only.** No `gcd`, no functional/preferences flags.
 - **Raw text body required.** Pre-parsed JSON bodies will not decode.
-- **Server-side only.** Web ingest via interception sources is roadmap, not v1.
+- **Server-side only.** Web ingest via interception sources is not supported.
 
 See the [website docs](https://www.walkeros.io/docs/transformers/ga4) for the
 authoritative reference and the

--- a/website/docs/destinations/web/d8a.mdx
+++ b/website/docs/destinations/web/d8a.mdx
@@ -1,0 +1,138 @@
+---
+title: d8a
+description: GA4-compatible, warehouse-native analytics
+path: /docs/destinations/web/d8a
+sidebar_position: 6
+package: '@walkeros/web-destination-d8a'
+---
+
+import data from '@walkeros/web-destination-d8a/walkerOS.json';
+import Configuration from '@site/src/components/snippets/_configuration.mdx';
+
+import WhereThisFits from '@site/src/components/snippets/_where-this-fits.mdx';
+
+# d8a
+
+<PackageLink
+  env="web"
+  github="packages/web/destinations/d8a"
+  npm="@walkeros/web-destination-d8a"
+/>
+
+[d8a](https://d8a.tech/) is a GA4-compatible, warehouse-native analytics
+platform. The destination sends walkerOS events to the d8a web tracker using the
+GA4 gtag-style `d8a()` API, so existing GA4 mappings translate directly.
+
+<WhereThisFits
+  pre={<>d8a is a <strong>web destination</strong> in the walkerOS flow:</>}
+  flowMap={{
+    destinations: { default: { label: 'Destination', text: 'd8a', highlight: true } },
+  }}
+/>
+
+## Installation
+
+<CodeSnippet
+  code={`npm install @walkeros/web-destination-d8a`}
+  language="bash"
+/>
+
+<Tabs groupId="mode">
+  <TabItem value="integrated" label="Integrated" default>
+
+<CodeSnippet
+  code={`import { startFlow } from '@walkeros/collector';
+import { destinationD8a } from '@walkeros/web-destination-d8a';
+
+await startFlow({
+  destinations: {
+    d8a: {
+      code: destinationD8a,
+      config: {
+        settings: {
+          property_id: '80e1d6d0-560d-419f-ac2a-fe9281e93386',
+          server_container_url:
+            'https://global.t.d8a.tech/80e1d6d0-560d-419f-ac2a-fe9281e93386/d/c',
+        },
+      },
+    },
+  },
+});`}
+  language="typescript"
+/>
+
+  </TabItem>
+  <TabItem value="bundled" label="Bundled">
+
+Add to your `flow.json` destinations:
+
+<CodeSnippet
+  code={`"destinations": {
+  "d8a": {
+    "package": "@walkeros/web-destination-d8a",
+    "config": {
+      "settings": {
+        "property_id": "80e1d6d0-560d-419f-ac2a-fe9281e93386",
+        "server_container_url": "https://global.t.d8a.tech/80e1d6d0-560d-419f-ac2a-fe9281e93386/d/c"
+      }
+    }
+  }
+}`}
+  language="json"
+/>
+
+[See bundled mode setup](/docs/getting-started/modes/bundled) | [CLI reference](/docs/apps/cli)
+
+  </TabItem>
+</Tabs>
+
+## Event Mapping
+
+By default, walkerOS event names are converted to snake_case and sent with the
+configured property ID as `send_to`. Override the name and shape per event the
+same way you would for GA4:
+
+<CodeSnippet
+  code={`mapping: {
+  order: {
+    complete: {
+      name: 'purchase',
+      data: {
+        map: {
+          transaction_id: 'data.id',
+          value: 'data.total',
+          currency: { key: 'data.currency', value: 'EUR' },
+        },
+      },
+    },
+  },
+}`}
+  language="typescript"
+/>
+
+This produces:
+
+<CodeSnippet
+  code={`d8a('event', 'purchase', {
+  transaction_id: '0rd3r1d',
+  value: 555,
+  currency: 'EUR',
+  send_to: '80e1d6d0-560d-419f-ac2a-fe9281e93386',
+});`}
+  language="typescript"
+/>
+
+## Consent Mode
+
+The destination supports d8a's gtag-compatible consent mode. By default,
+walkerOS consent keys map to d8a consent fields:
+
+| walkerOS consent key | d8a consent fields                                 |
+| -------------------- | -------------------------------------------------- |
+| `marketing`          | `ad_storage`, `ad_user_data`, `ad_personalization` |
+| `functional`         | `analytics_storage`                                |
+
+Disable consent mode with `como: false`, or provide a custom mapping via the
+`como` setting.
+
+<Configuration type="destination" data={data} />

--- a/website/docs/getting-started/flow/contract.mdx
+++ b/website/docs/getting-started/flow/contract.mdx
@@ -35,7 +35,7 @@ A contract is the schema for your event data: which fields are required, what ty
 A contract is a single, inheritable description of what your events should look like. It does not enforce anything at runtime: tools and humans read it for governance, documentation, and schema-driven workflows. Without a contract, schema rules can live inline (`validate:` on each step), which duplicates across flows.
 
 - **Single source of truth.** Define `product add` requirements once. Every flow that ships these events references the same definition.
-- **Inheritance.** Layer additional rules on top with `extends` (for example, `web_loggedin` extends `web` extends `default`) rather than copying.
+- **Inheritance.** Layer additional rules on top with `extend` (for example, `web_loggedin` extend `web` extend `default`) rather than copying.
 - **Versioned.** `tagging` tracks contract revisions alongside the events they govern.
 - **Self-documenting.** Each schema is JSON Schema, so `description` and `examples` annotate fields the same way humans and tools read them.
 - **Decoupled from enforcement.** Contracts describe what events should look like, step-level `validate:` references them, consumers decide whether to enforce.
@@ -49,7 +49,7 @@ If your flow has a single throwaway event, you do not need a contract. Reach for
 
 | Field | Purpose |
 |-------|---------|
-| `extends?` | Inherit from another named contract |
+| `extend?` | Inherit from another named contract |
 | `tagging?` | Integer revision marker |
 | `description?` | Human-readable note |
 | `events?` | Entity-action keyed JSON Schemas, applied per event |
@@ -80,7 +80,7 @@ If your flow has a single throwaway event, you do not need a contract. Reach for
       }
     },
     "web": {
-      "extends": "default",
+      "extend": "default",
       "events": {
         "product": {
           "add": {
@@ -135,17 +135,17 @@ Inside `events`, entity-action keyed entries define JSON Schemas for a partial `
 }
 ```
 
-## Inheritance with extends
+## Inheritance with extend
 
-Use `extends` to inherit from another named contract. Inheritance is additive:
+Use `extend` to inherit from another named contract. Inheritance is additive:
 
 - **`schema`** merges additively across the chain (deep merge of `properties`, union of `required`)
 - **`events`** merge at the entity-action level
 - **Scalars** (`tagging`, `description`): child overrides if set, otherwise inherited from parent
-- **Chains supported**: `web_loggedin` extends `web` extends `default`
+- **Chains supported**: `web_loggedin` extend `web` extend `default`
 - **Circular references** are detected and throw
 
-Extends chains are resolved first, then wildcards expand on the merged result. Schema merging follows the same additive rules as wildcard merging (see [Merge rules](#merge-rules)), so the same limitations on JSON Schema composition keywords apply.
+Extend chains are resolved first, then wildcards expand on the merged result. Schema merging follows the same additive rules as wildcard merging (see [Merge rules](#merge-rules)), so the same limitations on JSON Schema composition keywords apply.
 
 ```json
 "contract": {
@@ -158,7 +158,7 @@ Extends chains are resolved first, then wildcards expand on the merged result. S
     }
   },
   "web": {
-    "extends": "default",
+    "extend": "default",
     "events": {
       "product": {
         "add": { "properties": { "data": { "required": ["id", "quantity"] } } }
@@ -166,7 +166,7 @@ Extends chains are resolved first, then wildcards expand on the merged result. S
     }
   },
   "web_loggedin": {
-    "extends": "web",
+    "extend": "web",
     "schema": {
       "properties": {
         "user": {
@@ -219,7 +219,7 @@ This difference is intentional. Contracts express cumulative requirements (entit
 
 ### Merge rules
 
-When multiple wildcard levels (or `extends` chains) match, the JSON Schemas merge with these rules:
+When multiple wildcard levels (or `extend` chains) match, the JSON Schemas merge with these rules:
 
 | JSON Schema keyword | Merge behavior |
 |---------------------|----------------|
@@ -234,7 +234,7 @@ Annotations stay on the source contract for tooling (CLI hints, IDE descriptions
 
 ## `$contract` references
 
-Reference any part of a resolved contract with `$contract.<name>.<path>`. The contract is fully resolved (extends + wildcards) before path access, so the returned value is the merged shape, not the raw entry.
+Reference any part of a resolved contract with `$contract.<name>.<path>`. The contract is fully resolved (extend + wildcards) before path access, so the returned value is the merged shape, not the raw entry.
 
 ```json
 "destinations": {
@@ -279,7 +279,7 @@ walkeros validate flow.json
 The contract validator checks:
 
 - `tagging` is a non-negative integer (if present)
-- `extends` references exist and are not circular
+- `extend` references exist and are not circular
 - Entity and action keys are non-empty
 - `schema`, if present, is a valid JSON Schema object
 - Each event entry is a valid JSON Schema object
@@ -309,7 +309,7 @@ Top-level `variables` holds reusable values that any part of the config can pull
 }
 ```
 
-Use `variables` when the same JSON Schema fragment shows up in many events. For contract-shaped reuse across flows, prefer `extends`.
+Use `variables` when the same JSON Schema fragment shows up in many events. For contract-shaped reuse across flows, prefer `extend`.
 
 </details>
 
@@ -356,7 +356,7 @@ A shorter end-to-end illustration:
       }
     },
     "web_loggedin": {
-      "extends": "default",
+      "extend": "default",
       "schema": {
         "properties": {
           "user": {

--- a/website/docs/getting-started/flow/validate.mdx
+++ b/website/docs/getting-started/flow/validate.mdx
@@ -156,7 +156,7 @@ The recommended logical position is after the step's `before` chain and before t
   language="json"
 />
 
-See [Contract](/docs/getting-started/flow/contract) for the full contract shape, inheritance with `extends`, and wildcard merging.
+See [Contract](/docs/getting-started/flow/contract) for the full contract shape, inheritance with `extend`, and wildcard merging.
 
 ## Format layer
 

--- a/website/docs/guides/reference-syntax.mdx
+++ b/website/docs/guides/reference-syntax.mdx
@@ -122,7 +122,7 @@ token after `:` is used verbatim.
 ## `$contract.` — contract references
 
 Inject a fragment of a named contract entry. Same whole-string and deep-path
-rules as `$var.`. The contract is fully resolved (extends + wildcards) before
+rules as `$var.`. The contract is fully resolved (extend + wildcards) before
 path access, so the value you get is the merged shape.
 
 See [Contract](/docs/getting-started/flow/contract) for the full structure.

--- a/website/docs/mapping/rule.mdx
+++ b/website/docs/mapping/rule.mdx
@@ -286,6 +286,61 @@ The same event can be transformed at both stations:
 4. GA4 receives:         "view_item"
 ```
 
+## Patching package-shipped rules
+
+Some packages (such as `@walkeros/transformer-ga4`) ship their own default
+mapping rules. Normally, a user rule at the same key replaces the default in
+full. Two keywords change that:
+
+### `extend` (config layer)
+
+`extend` holds a **partial rule** that is deep-merged onto the package-shipped
+default at the same key instead of replacing it. The merge happens once at
+init, before any event is evaluated. A `null` value clears an inherited field.
+
+Use `extend` when you want to add or override one field of a default rule while
+inheriting the rest unchanged.
+
+### `remove` (output layer)
+
+`remove` is a list of **dotted paths** stripped from the produced data payload
+after evaluation, regardless of how each field was produced (`map`, `fn`,
+`include`, etc.). Applied last, so it always wins.
+
+Use `remove` when you must not emit a field (PII, a vendor-reserved parameter)
+but do not want to rewrite the full rule.
+
+### Mode switching
+
+A rule that has **neither** `extend` nor `remove` keeps today's replace
+behavior. Presence of either keyword activates merge mode for that rule.
+
+### Example: patch a GA4 decoder rule
+
+The transformer-ga4 `purchase` default ships `id`, `currency`, `total`, `tax`,
+`shipping`, and `coupon`. The config below adds `affiliation` from a GA4 event
+parameter and drops `currency` from the output, keeping all other default
+fields:
+
+```json
+{
+  "settings": {
+    "mapping": {
+      "purchase": {
+        "extend": {
+          "data": { "map": { "affiliation": "params.ep.affiliation" } }
+        },
+        "remove": ["currency"]
+      }
+    }
+  }
+}
+```
+
+`extend.data.map` is deep-merged onto the default `data.map`, so `affiliation`
+is added alongside the existing keys. `remove: ["currency"]` then strips that
+field from the final payload.
+
 ## See also
 
 - [Mapping.Value](./value.mdx): the eight value forms used in every rule field

--- a/website/package.json
+++ b/website/package.json
@@ -65,6 +65,7 @@
     "@walkeros/web-destination-amplitude": "^4.1.0",
     "@walkeros/web-destination-api": "^4.1.0",
     "@walkeros/web-destination-clarity": "^4.1.0",
+    "@walkeros/web-destination-d8a": "^4.1.0",
     "@walkeros/web-destination-fullstory": "^4.1.0",
     "@walkeros/web-destination-gtag": "^4.1.0",
     "@walkeros/web-destination-heap": "^4.1.0",

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -208,6 +208,11 @@ const sidebars: SidebarsConfig = {
                 },
                 {
                   type: 'doc',
+                  id: 'destinations/web/d8a',
+                  className: 'sidebar-badge-web',
+                },
+                {
+                  type: 'doc',
                   id: 'destinations/web/fullstory',
                   className: 'sidebar-badge-web',
                 },

--- a/website/static/schema/flow/v4.json
+++ b/website/static/schema/flow/v4.json
@@ -16,114 +16,62 @@
       "title": "Flow.Variables",
       "description": "Reusable values referenced via $var.name (with optional deep paths). Whole-string refs preserve native type; inline interpolation requires scalars."
     },
-    "FlowContractSchemaEntry": {
-      "type": "object",
-      "propertyNames": {
-        "type": "string"
-      },
-      "additionalProperties": {},
-      "title": "Flow.ContractSchemaEntry",
-      "description": "JSON Schema object for event validation with description/examples annotations."
-    },
-    "FlowContractActions": {
-      "type": "object",
-      "propertyNames": {
-        "type": "string"
-      },
-      "additionalProperties": {
-        "description": "JSON Schema object for event validation with description/examples annotations",
-        "allOf": [
-          {
-            "$ref": "#/definitions/FlowContractSchemaEntry"
-          }
-        ]
-      },
-      "title": "Flow.ContractActions",
-      "description": "Action-level contract entries keyed by action name."
-    },
-    "FlowContractEvents": {
-      "type": "object",
-      "propertyNames": {
-        "type": "string"
-      },
-      "additionalProperties": {
-        "description": "Action-level contract entries",
-        "allOf": [
-          {
-            "$ref": "#/definitions/FlowContractActions"
-          }
-        ]
-      },
-      "title": "Flow.ContractEvents",
-      "description": "Entity-action event schemas (entity → action → schema)."
-    },
-    "FlowContractRule": {
+    "ContractRule": {
       "type": "object",
       "properties": {
-        "extends": {
-          "description": "Inherit from another named contract",
+        "extend": {
           "type": "string"
         },
         "tagging": {
-          "description": "Tagging level (used by validators / runtime tagging policy)",
           "type": "number"
         },
         "description": {
-          "description": "Human-readable description",
           "type": "string"
         },
-        "globals": {
-          "description": "JSON Schema for event.globals",
-          "allOf": [
-            {
-              "$ref": "#/definitions/FlowContractSchemaEntry"
-            }
-          ]
-        },
-        "context": {
-          "description": "JSON Schema for event.context",
-          "allOf": [
-            {
-              "$ref": "#/definitions/FlowContractSchemaEntry"
-            }
-          ]
-        },
-        "custom": {
-          "description": "JSON Schema for event.custom",
-          "allOf": [
-            {
-              "$ref": "#/definitions/FlowContractSchemaEntry"
-            }
-          ]
-        },
-        "user": {
-          "description": "JSON Schema for event.user",
-          "allOf": [
-            {
-              "$ref": "#/definitions/FlowContractSchemaEntry"
-            }
-          ]
-        },
-        "consent": {
-          "description": "JSON Schema for event.consent",
-          "allOf": [
-            {
-              "$ref": "#/definitions/FlowContractSchemaEntry"
-            }
-          ]
-        },
         "events": {
-          "description": "Entity-action event schemas",
           "allOf": [
             {
-              "$ref": "#/definitions/FlowContractEvents"
+              "$ref": "#/definitions/ValidateEvents"
+            }
+          ]
+        },
+        "schema": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/JsonSchema"
             }
           ]
         }
       },
       "additionalProperties": false,
       "title": "Flow.ContractRule",
-      "description": "Named contract rule with optional sections (globals/context/custom/user/consent) and event schemas."
+      "description": "Named contract entry"
+    },
+    "JsonSchema": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {},
+      "title": "JsonSchema",
+      "description": "Structural JSON Schema fragment (Record<string, unknown>)"
+    },
+    "ValidateEvents": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "propertyNames": {
+          "type": "string"
+        },
+        "additionalProperties": {
+          "$ref": "#/definitions/JsonSchema"
+        }
+      },
+      "title": "ValidateEvents",
+      "description": "Entity-action keyed JSON Schemas"
     },
     "FlowContract": {
       "type": "object",
@@ -131,15 +79,10 @@
         "type": "string"
       },
       "additionalProperties": {
-        "description": "Named contract rule with optional sections and events",
-        "allOf": [
-          {
-            "$ref": "#/definitions/FlowContractRule"
-          }
-        ]
+        "$ref": "#/definitions/ContractRule"
       },
       "title": "Flow.Contract",
-      "description": "Named contracts map with optional extends inheritance."
+      "description": "Named contracts map with optional extend inheritance."
     },
     "FlowSettings": {
       "type": "object",
@@ -263,7 +206,7 @@
       "required": ["push"],
       "additionalProperties": false,
       "title": "Flow.Code",
-      "description": "Inline code block for custom sources / transformers / destinations / stores."
+      "description": "Inline code block (object form) for custom sources / transformers / destinations / stores. Use `import` on the step to select a named export from a package."
     },
     "FlowSourceConfig": {
       "type": "object",
@@ -292,7 +235,7 @@
       "title": "Source.BaseEnv",
       "description": "Source environment configuration (Source.BaseEnv overrides)."
     },
-    "MatcherRouteSpec": {
+    "Route": {
       "anyOf": [
         {
           "type": "string"
@@ -300,40 +243,99 @@
         {
           "type": "array",
           "items": {
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/definitions/Route"
+              }
+            ]
           }
         },
         {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "match": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/MatcherExpression"
-                  },
-                  {
-                    "type": "string",
-                    "const": "*"
-                  }
-                ]
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "match": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/MatcherExpression"
+                    }
+                  ]
+                },
+                "next": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Route"
+                    }
+                  ]
+                }
               },
-              "next": {
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/MatcherRouteSpec"
-                  }
-                ]
-              }
+              "required": ["next"],
+              "additionalProperties": false
             },
-            "required": ["match", "next"],
-            "additionalProperties": false
-          }
+            {
+              "type": "object",
+              "properties": {
+                "match": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/MatcherExpression"
+                    }
+                  ]
+                },
+                "one": {
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/Route"
+                      }
+                    ]
+                  }
+                }
+              },
+              "required": ["one"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "match": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/MatcherExpression"
+                    }
+                  ]
+                },
+                "many": {
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/Route"
+                      }
+                    ]
+                  }
+                }
+              },
+              "required": ["many"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "match": {
+                  "$ref": "#/definitions/MatcherExpression"
+                }
+              },
+              "required": ["match"],
+              "additionalProperties": false
+            }
+          ]
         }
       ],
-      "title": "Matcher.RouteSpec",
-      "description": "Routable next target: ID, ID list, or list of {match, next} rules."
+      "title": "Route",
+      "description": "Recursive route: string ID, sequence of routes, or a RouteConfig (next/one/many/gate)."
     },
     "MatcherExpression": {
       "anyOf": [
@@ -487,45 +489,45 @@
       "title": "Flow.StepExamples",
       "description": "Named step examples keyed by scenario name."
     },
-    "CacheConfig": {
+    "EventCacheConfig": {
       "type": "object",
       "properties": {
-        "full": {
-          "description": "Stop flow on cache HIT (default: false). When true, skip remaining steps and return cached value.",
+        "stop": {
+          "description": "Stop the chain on cache HIT (default: false). When true, skip remaining steps and return cached value.",
           "type": "boolean"
         },
         "store": {
           "description": "Store ID for persistent caching (references a configured store)",
           "type": "string"
         },
+        "namespace": {
+          "description": "Optional key prefix. Omit to write keys directly to the store. Same store + same key + same namespace = same cache entry.",
+          "type": "string"
+        },
         "rules": {
           "minItems": 1,
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CacheRule"
+            "$ref": "#/definitions/EventCacheRule"
           },
           "description": "Cache rules — at least one required"
         }
       },
       "required": ["rules"],
       "additionalProperties": false,
-      "title": "Cache.Config",
-      "description": "Top-level cache configuration for a pipeline step (destination / transformer / source ref)."
+      "title": "EventCache.Config",
+      "description": "Top-level cache configuration for an event-context pipeline step (source / transformer / destination)."
     },
-    "CacheRule": {
+    "EventCacheRule": {
       "type": "object",
       "properties": {
         "match": {
-          "anyOf": [
+          "description": "Optional match expression — omit for always-match.",
+          "allOf": [
             {
               "$ref": "#/definitions/MatcherExpression"
-            },
-            {
-              "type": "string",
-              "const": "*"
             }
-          ],
-          "description": "Match expression or wildcard to determine when this rule applies"
+          ]
         },
         "key": {
           "minItems": 1,
@@ -538,7 +540,7 @@
         "ttl": {
           "type": "number",
           "exclusiveMinimum": 0,
-          "description": "Time-to-live in seconds for cached entries"
+          "description": "Time-to-live in seconds"
         },
         "update": {
           "description": "Response mutations applied on cache hit (key → Value mapping)",
@@ -551,10 +553,10 @@
           }
         }
       },
-      "required": ["match", "key", "ttl"],
+      "required": ["key", "ttl"],
       "additionalProperties": false,
-      "title": "Cache.Rule",
-      "description": "Single caching rule: when it applies (match), what keys it keys off, TTL, and optional response mutations on hit."
+      "title": "EventCache.Rule",
+      "description": "Single event-cache rule: when it applies (match), what event fields it keys off, TTL, and optional response mutations on hit."
     },
     "MappingValue": {
       "title": "Mapping.Value",
@@ -702,6 +704,34 @@
       "title": "Mapping.ValueConfig",
       "description": "Object-form value transformation with map/loop/set/condition/consent etc."
     },
+    "Validate": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "description": "Validate event structure against the standard event format",
+          "type": "boolean"
+        },
+        "events": {
+          "description": "Per entity-action JSON Schemas to validate matching events against",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ValidateEvents"
+            }
+          ]
+        },
+        "schema": {
+          "description": "A single JSON Schema applied to every event this step handles",
+          "allOf": [
+            {
+              "$ref": "#/definitions/JsonSchema"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "title": "Validate",
+      "description": "Step-level validation: { format?, events?, schema? }"
+    },
     "FlowSource": {
       "type": "object",
       "properties": {
@@ -711,20 +741,17 @@
           "minLength": 1
         },
         "code": {
-          "description": "Either a named export string (e.g., \"sourceExpress\") or an inline code object with push function",
-          "anyOf": [
+          "description": "Inline code definition (object form). For a named export from a package, use `import` instead.",
+          "allOf": [
             {
-              "type": "string"
-            },
-            {
-              "description": "Inline code for custom components",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/FlowCode"
-                }
-              ]
+              "$ref": "#/definitions/FlowCode"
             }
           ]
+        },
+        "import": {
+          "description": "Named export from `package` to import as this step's implementation. Top-level identifier only. Requires `package`. Mutually exclusive with `code`.",
+          "type": "string",
+          "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$"
         },
         "config": {
           "description": "Source-specific configuration object",
@@ -758,7 +785,7 @@
           "description": "Pre-collector transformer chain. String, string[], or Route[] for conditional routing based on ingest data.",
           "allOf": [
             {
-              "$ref": "#/definitions/MatcherRouteSpec"
+              "$ref": "#/definitions/Route"
             }
           ]
         },
@@ -766,7 +793,7 @@
           "description": "Pre-source transformer chain (consent-exempt). Handles transport-level preprocessing.",
           "allOf": [
             {
-              "$ref": "#/definitions/MatcherRouteSpec"
+              "$ref": "#/definitions/Route"
             }
           ]
         },
@@ -782,7 +809,14 @@
           "description": "Cache configuration for this source (match → key → ttl rules)",
           "allOf": [
             {
-              "$ref": "#/definitions/CacheConfig"
+              "$ref": "#/definitions/EventCacheConfig"
+            }
+          ]
+        },
+        "validate": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Validate"
             }
           ]
         }
@@ -818,6 +852,84 @@
       "title": "Destination.Env",
       "description": "Destination environment configuration."
     },
+    "RouteWithoutMany": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {
+                "$ref": "#/definitions/RouteWithoutMany"
+              }
+            ]
+          }
+        },
+        {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "match": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/MatcherExpression"
+                    }
+                  ]
+                },
+                "next": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/RouteWithoutMany"
+                    }
+                  ]
+                }
+              },
+              "required": ["next"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "match": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/MatcherExpression"
+                    }
+                  ]
+                },
+                "one": {
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/RouteWithoutMany"
+                      }
+                    ]
+                  }
+                }
+              },
+              "required": ["one"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "match": {
+                  "$ref": "#/definitions/MatcherExpression"
+                }
+              },
+              "required": ["match"],
+              "additionalProperties": false
+            }
+          ]
+        }
+      ],
+      "title": "RouteWithoutMany",
+      "description": "Route variant for post-collector positions (destination.before). Excludes the many operator — post-collector fan-out uses the destinations map."
+    },
     "FlowDestination": {
       "type": "object",
       "properties": {
@@ -827,20 +939,17 @@
           "minLength": 1
         },
         "code": {
-          "description": "Either a named export string (e.g., \"destinationAnalytics\") or an inline code object with push function",
-          "anyOf": [
+          "description": "Inline code definition (object form). For a named export from a package, use `import` instead.",
+          "allOf": [
             {
-              "type": "string"
-            },
-            {
-              "description": "Inline code for custom components",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/FlowCode"
-                }
-              ]
+              "$ref": "#/definitions/FlowCode"
             }
           ]
+        },
+        "import": {
+          "description": "Named export from `package` to import as this step's implementation. Top-level identifier only. Requires `package`. Mutually exclusive with `code`.",
+          "type": "string",
+          "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$"
         },
         "config": {
           "description": "Destination-specific configuration object",
@@ -867,18 +976,18 @@
           ]
         },
         "before": {
-          "description": "Post-collector transformer chain. String, string[], or Route[] for conditional routing.",
+          "description": "Post-collector transformer chain. String, string[], or Route[] for conditional routing. `many` is not valid here — use multiple destinations for post-collector fan-out.",
           "allOf": [
             {
-              "$ref": "#/definitions/MatcherRouteSpec"
+              "$ref": "#/definitions/RouteWithoutMany"
             }
           ]
         },
         "next": {
-          "description": "Post-push transformer chain. Push response available at context.ingest._response.",
+          "description": "Post-push transformer chain. Push response available at context.ingest._response. `many` is not valid here — use multiple destinations for post-collector fan-out.",
           "allOf": [
             {
-              "$ref": "#/definitions/MatcherRouteSpec"
+              "$ref": "#/definitions/RouteWithoutMany"
             }
           ]
         },
@@ -894,7 +1003,14 @@
           "description": "Cache configuration for this destination (match → key → ttl rules)",
           "allOf": [
             {
-              "$ref": "#/definitions/CacheConfig"
+              "$ref": "#/definitions/EventCacheConfig"
+            }
+          ]
+        },
+        "validate": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Validate"
             }
           ]
         }
@@ -920,20 +1036,17 @@
           "minLength": 1
         },
         "code": {
-          "description": "Either a named export string (e.g., \"transformerEnricher\") or an inline code object with push function",
-          "anyOf": [
+          "description": "Inline code definition (object form). For a named export from a package, use `import` instead.",
+          "allOf": [
             {
-              "type": "string"
-            },
-            {
-              "description": "Inline code for custom components",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/FlowCode"
-                }
-              ]
+              "$ref": "#/definitions/FlowCode"
             }
           ]
+        },
+        "import": {
+          "description": "Named export from `package` to import as this step's implementation. Top-level identifier only. Requires `package`. Mutually exclusive with `code`.",
+          "type": "string",
+          "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$"
         },
         "config": {
           "description": "Transformer-specific configuration object",
@@ -955,7 +1068,7 @@
           "description": "Pre-transformer chain. Runs before this transformer push function.",
           "allOf": [
             {
-              "$ref": "#/definitions/MatcherRouteSpec"
+              "$ref": "#/definitions/Route"
             }
           ]
         },
@@ -963,7 +1076,7 @@
           "description": "Next transformer in chain. String, string[], or Route[] for conditional routing.",
           "allOf": [
             {
-              "$ref": "#/definitions/MatcherRouteSpec"
+              "$ref": "#/definitions/Route"
             }
           ]
         },
@@ -987,7 +1100,14 @@
           "description": "Cache configuration for this transformer (match → key → ttl rules)",
           "allOf": [
             {
-              "$ref": "#/definitions/CacheConfig"
+              "$ref": "#/definitions/EventCacheConfig"
+            }
+          ]
+        },
+        "validate": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Validate"
             }
           ]
         }
@@ -1023,6 +1143,54 @@
       "title": "Store.Env",
       "description": "Store environment configuration."
     },
+    "StoreCacheConfig": {
+      "type": "object",
+      "properties": {
+        "store": {
+          "description": "Store ID for persistent caching (references a configured store)",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Optional key prefix. Omit to default to the host store id. Empty string is rejected.",
+          "type": "string",
+          "minLength": 1
+        },
+        "rules": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StoreCacheRule"
+          },
+          "description": "Cache rules — at least one required"
+        }
+      },
+      "required": ["rules"],
+      "additionalProperties": false,
+      "title": "StoreCache.Config",
+      "description": "Top-level cache configuration for a store wrapper. No `stop` (always falls through on miss); namespace defaults to the host store id."
+    },
+    "StoreCacheRule": {
+      "type": "object",
+      "properties": {
+        "match": {
+          "description": "Optional match expression evaluated against `{ key, value? }`. Omit for always-match.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MatcherExpression"
+            }
+          ]
+        },
+        "ttl": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Time-to-live in seconds"
+        }
+      },
+      "required": ["ttl"],
+      "additionalProperties": false,
+      "title": "StoreCache.Rule",
+      "description": "Single store-cache rule: optional match against `{ key, value? }` and a TTL. No `key` (caller provides it) and no `update` (no event to mutate)."
+    },
     "FlowStore": {
       "type": "object",
       "properties": {
@@ -1032,20 +1200,17 @@
           "minLength": 1
         },
         "code": {
-          "description": "Named export string or inline code definition",
-          "anyOf": [
+          "description": "Inline code definition (object form). For a named export from a package, use `import` instead.",
+          "allOf": [
             {
-              "type": "string"
-            },
-            {
-              "description": "Inline code for custom components",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/FlowCode"
-                }
-              ]
+              "$ref": "#/definitions/FlowCode"
             }
           ]
+        },
+        "import": {
+          "description": "Named export from `package` to import as this step's implementation. Top-level identifier only. Requires `package`. Mutually exclusive with `code`.",
+          "type": "string",
+          "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$"
         },
         "config": {
           "description": "Store-specific configuration object",
@@ -1060,6 +1225,14 @@
           "allOf": [
             {
               "$ref": "#/definitions/FlowStoreEnv"
+            }
+          ]
+        },
+        "cache": {
+          "description": "Cache configuration for this store (TTL-only rules, optional recursive `cache.store`)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StoreCacheConfig"
             }
           ]
         },
@@ -1082,7 +1255,7 @@
       },
       "additionalProperties": false,
       "title": "Flow.Store",
-      "description": "Store package reference with configuration, env, and examples."
+      "description": "Store package reference with configuration, env, cache, and examples."
     },
     "FlowCollector": {
       "title": "Collector.InitConfig",
@@ -1209,7 +1382,7 @@
           ]
         },
         "contract": {
-          "description": "Named contracts with extends inheritance and dot-path references",
+          "description": "Named contracts with extend inheritance and dot-path references",
           "allOf": [
             {
               "$ref": "#/definitions/FlowContract"

--- a/website/static/schema/flow/v4.json
+++ b/website/static/schema/flow/v4.json
@@ -1279,6 +1279,96 @@
             "type": "string"
           },
           "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "package": {
+                "description": "Package specifier with optional version (e.g., \"@walkeros/web-source-browser@2.0.0\")",
+                "type": "string",
+                "minLength": 1
+              },
+              "code": {
+                "description": "Inline code definition (object form). For a named export from a package, use `import` instead.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowCode"
+                  }
+                ]
+              },
+              "import": {
+                "description": "Named export from `package` to import as this step's implementation. Top-level identifier only. Requires `package`. Mutually exclusive with `code`.",
+                "type": "string",
+                "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$"
+              },
+              "config": {
+                "description": "Source-specific configuration object",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowSourceConfig"
+                  }
+                ]
+              },
+              "env": {
+                "description": "Source environment configuration",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowSourceEnv"
+                  }
+                ]
+              },
+              "primary": {
+                "description": "Mark as primary source (provides main elb). Only one source should be primary.",
+                "type": "boolean"
+              },
+              "variables": {
+                "description": "Source-level variables (highest priority in cascade)",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowVariables"
+                  }
+                ]
+              },
+              "next": {
+                "description": "Pre-collector transformer chain. String, string[], or Route[] for conditional routing based on ingest data.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Route"
+                  }
+                ]
+              },
+              "before": {
+                "description": "Pre-source transformer chain (consent-exempt). Handles transport-level preprocessing.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Route"
+                  }
+                ]
+              },
+              "examples": {
+                "description": "Named step examples for testing and documentation (stripped during bundling)",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowStepExamples"
+                  }
+                ]
+              },
+              "cache": {
+                "description": "Cache configuration for this source (match → key → ttl rules)",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/EventCacheConfig"
+                  }
+                ]
+              },
+              "validate": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Validate"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false,
+            "title": "Flow.Source",
             "description": "Source package reference with configuration",
             "allOf": [
               {
@@ -1294,6 +1384,92 @@
             "type": "string"
           },
           "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "package": {
+                "description": "Package specifier with optional version (e.g., \"@walkeros/web-destination-gtag@2.0.0\")",
+                "type": "string",
+                "minLength": 1
+              },
+              "code": {
+                "description": "Inline code definition (object form). For a named export from a package, use `import` instead.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowCode"
+                  }
+                ]
+              },
+              "import": {
+                "description": "Named export from `package` to import as this step's implementation. Top-level identifier only. Requires `package`. Mutually exclusive with `code`.",
+                "type": "string",
+                "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$"
+              },
+              "config": {
+                "description": "Destination-specific configuration object",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowDestinationConfig"
+                  }
+                ]
+              },
+              "env": {
+                "description": "Destination environment configuration",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowDestinationEnv"
+                  }
+                ]
+              },
+              "variables": {
+                "description": "Destination-level variables (highest priority in cascade)",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowVariables"
+                  }
+                ]
+              },
+              "before": {
+                "description": "Post-collector transformer chain. String, string[], or Route[] for conditional routing. `many` is not valid here — use multiple destinations for post-collector fan-out.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/RouteWithoutMany"
+                  }
+                ]
+              },
+              "next": {
+                "description": "Post-push transformer chain. Push response available at context.ingest._response. `many` is not valid here — use multiple destinations for post-collector fan-out.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/RouteWithoutMany"
+                  }
+                ]
+              },
+              "examples": {
+                "description": "Named step examples for testing and documentation (stripped during bundling)",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowStepExamples"
+                  }
+                ]
+              },
+              "cache": {
+                "description": "Cache configuration for this destination (match → key → ttl rules)",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/EventCacheConfig"
+                  }
+                ]
+              },
+              "validate": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Validate"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false,
+            "title": "Flow.Destination",
             "description": "Destination package reference with configuration",
             "allOf": [
               {
@@ -1309,6 +1485,92 @@
             "type": "string"
           },
           "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "package": {
+                "description": "Package specifier with optional version (e.g., \"@walkeros/transformer-enricher@1.0.0\")",
+                "type": "string",
+                "minLength": 1
+              },
+              "code": {
+                "description": "Inline code definition (object form). For a named export from a package, use `import` instead.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowCode"
+                  }
+                ]
+              },
+              "import": {
+                "description": "Named export from `package` to import as this step's implementation. Top-level identifier only. Requires `package`. Mutually exclusive with `code`.",
+                "type": "string",
+                "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$"
+              },
+              "config": {
+                "description": "Transformer-specific configuration object",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowTransformerConfig"
+                  }
+                ]
+              },
+              "env": {
+                "description": "Transformer environment configuration",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowTransformerEnv"
+                  }
+                ]
+              },
+              "before": {
+                "description": "Pre-transformer chain. Runs before this transformer push function.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Route"
+                  }
+                ]
+              },
+              "next": {
+                "description": "Next transformer in chain. String, string[], or Route[] for conditional routing.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Route"
+                  }
+                ]
+              },
+              "variables": {
+                "description": "Transformer-level variables (highest priority in cascade)",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowVariables"
+                  }
+                ]
+              },
+              "examples": {
+                "description": "Named step examples for testing and documentation (stripped during bundling)",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowStepExamples"
+                  }
+                ]
+              },
+              "cache": {
+                "description": "Cache configuration for this transformer (match → key → ttl rules)",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/EventCacheConfig"
+                  }
+                ]
+              },
+              "validate": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Validate"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false,
+            "title": "Flow.Transformer",
             "description": "Transformer package reference with configuration",
             "allOf": [
               {
@@ -1324,6 +1586,69 @@
             "type": "string"
           },
           "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "package": {
+                "description": "Store package specifier with optional version",
+                "type": "string",
+                "minLength": 1
+              },
+              "code": {
+                "description": "Inline code definition (object form). For a named export from a package, use `import` instead.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowCode"
+                  }
+                ]
+              },
+              "import": {
+                "description": "Named export from `package` to import as this step's implementation. Top-level identifier only. Requires `package`. Mutually exclusive with `code`.",
+                "type": "string",
+                "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$"
+              },
+              "config": {
+                "description": "Store-specific configuration object",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowStoreConfig"
+                  }
+                ]
+              },
+              "env": {
+                "description": "Store environment configuration",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowStoreEnv"
+                  }
+                ]
+              },
+              "cache": {
+                "description": "Cache configuration for this store (TTL-only rules, optional recursive `cache.store`)",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/StoreCacheConfig"
+                  }
+                ]
+              },
+              "variables": {
+                "description": "Store-level variables (highest priority in cascade)",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowVariables"
+                  }
+                ]
+              },
+              "examples": {
+                "description": "Named step examples for testing and documentation (stripped during bundling)",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/FlowStepExamples"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false,
+            "title": "Flow.Store",
             "description": "Store package reference with configuration",
             "allOf": [
               {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mapping rules: add extend (patch/merge) and remove (output-field stripping).
  * Explorer: exposes $-ref completion helpers for custom inputs.
  * New d8a web destination and docs.

* **Improvements**
  * Mapping: remove directive trims output payloads after evaluation.

* **Bug Fixes**
  * Meta Conversions API: access token sent in Authorization header (not URL).

* **Breaking Changes**
  * Contract inheritance key renamed: extends → extend.
  * CLI simulate now returns unified simulation results with events and calls (replacing prior shape).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elbwalker/walkerOS/pull/648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->