### PR TITLE
fix(destination-piano): run setConfigurations after async script load

### DIFF
--- a/.changeset/piano-configure-after-script-load.md
+++ b/.changeset/piano-configure-after-script-load.md
@@ -1,0 +1,8 @@
+---
+'@walkeros/web-destination-piano': patch
+---
+
+With `loadScript: true`, `site` and `collectDomain` now reach the Piano SDK
+reliably. Configuration is applied after the injected script loads, instead of
+being silently skipped on a cold page. If the script fails to load (ad blocker,
+network, CDN), a warning is logged rather than sending unconfigured events.

--- a/packages/web/destinations/piano/src/index.test.ts
+++ b/packages/web/destinations/piano/src/index.test.ts
@@ -88,4 +88,27 @@ describe('destination piano', () => {
     expect(script.src).toBe(SCRIPT_SRC);
     expect(appendChild).toHaveBeenCalledWith(script);
   });
+
+  test('loadScript defers configuration until the script loads', async () => {
+    const setConfigurations = jest.fn();
+    const env: Env = {
+      window: {
+        pa: { setConfigurations, sendEvent: jest.fn(), sendEvents: jest.fn() },
+      },
+    };
+
+    const script = document.createElement('script');
+    jest.spyOn(document, 'createElement').mockReturnValue(script);
+    jest.spyOn(document.head, 'appendChild').mockImplementation((node) => node);
+
+    const elb = await register(env, { loadScript: true });
+    await elb(getEvent());
+
+    // The SDK loads asynchronously, so nothing is configured yet.
+    expect(setConfigurations).not.toHaveBeenCalled();
+
+    // Once the script fires onload, configuration runs.
+    script.onload?.(new Event('load'));
+    expect(setConfigurations).toHaveBeenCalledWith({ site, collectDomain });
+  });
 });

--- a/packages/web/destinations/piano/src/index.test.ts
+++ b/packages/web/destinations/piano/src/index.test.ts
@@ -1,4 +1,5 @@
 import type { Config, Env } from './types';
+import type { Destination } from '@walkeros/core';
 import { startFlow } from '@walkeros/collector';
 import { getEvent } from '@walkeros/core';
 import destinationPiano from '.';
@@ -110,5 +111,45 @@ describe('destination piano', () => {
     // Once the script fires onload, configuration runs.
     script.onload?.(new Event('load'));
     expect(setConfigurations).toHaveBeenCalledWith({ site, collectDomain });
+  });
+
+  test('warns when the Piano script fails to load', () => {
+    const setConfigurations = jest.fn();
+    const env: Env = {
+      window: {
+        pa: { setConfigurations, sendEvent: jest.fn(), sendEvents: jest.fn() },
+      },
+    };
+
+    const script = document.createElement('script');
+    jest.spyOn(document, 'createElement').mockReturnValue(script);
+    jest.spyOn(document.head, 'appendChild').mockImplementation((node) => node);
+
+    const warn = jest.fn();
+    const logger = {
+      error: jest.fn(),
+      warn,
+      info: jest.fn(),
+      debug: jest.fn(),
+      throw: jest.fn(),
+    } as unknown as Destination.Context['logger'];
+
+    destinationPiano.init?.({
+      id: 'piano',
+      config: { loadScript: true, settings: { site, collectDomain } },
+      env,
+      logger,
+      collector: {} as Destination.Context['collector'],
+    });
+
+    // A blocked or failed script never fires onload, so nothing is configured.
+    expect(setConfigurations).not.toHaveBeenCalled();
+
+    // onerror surfaces a single warning instead of failing silently.
+    script.onerror?.(new Event('error'));
+    expect(warn).toHaveBeenCalledWith(
+      'Piano Analytics script failed to load, destination not configured',
+    );
+    expect(setConfigurations).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/destinations/piano/src/index.ts
+++ b/packages/web/destinations/piano/src/index.ts
@@ -11,7 +11,7 @@ export const destinationPiano: Destination = {
 
   config: {},
 
-  init({ config, env }) {
+  init({ config, env, logger }) {
     const settings = config.settings || {};
 
     const configure = () => {
@@ -26,9 +26,15 @@ export const destinationPiano: Destination = {
     };
 
     // When we inject the SDK it loads asynchronously, so `window.pa` is not
-    // available in the same tick. Defer configuration until `onload` fires.
+    // available in the same tick. Defer configuration until `onload` fires,
+    // and warn if the script never loads (e.g. blocked or network failure) so
+    // the destination does not silently send unconfigured events.
     if (config.loadScript) {
-      addScript(SCRIPT_SRC, configure);
+      addScript(SCRIPT_SRC, configure, () =>
+        logger.warn(
+          'Piano Analytics script failed to load, destination not configured',
+        ),
+      );
     } else {
       configure();
     }
@@ -54,11 +60,16 @@ function resolvePa(env: Env): PianoAnalytics | undefined {
   );
 }
 
-function addScript(src = SCRIPT_SRC, onReady?: () => void) {
+function addScript(
+  src = SCRIPT_SRC,
+  onReady?: () => void,
+  onError?: () => void,
+) {
   if (typeof document === 'undefined') return;
   const script = document.createElement('script');
   script.src = src;
   if (onReady) script.onload = () => onReady();
+  if (onError) script.onerror = () => onError();
   document.head.appendChild(script);
 }
 

--- a/packages/web/destinations/piano/src/index.ts
+++ b/packages/web/destinations/piano/src/index.ts
@@ -14,15 +14,23 @@ export const destinationPiano: Destination = {
   init({ config, env }) {
     const settings = config.settings || {};
 
-    if (config.loadScript) addScript();
+    const configure = () => {
+      const pa = resolvePa(env);
+      if (pa && isDefined(settings.site) && isDefined(settings.collectDomain)) {
+        pa.setConfigurations({
+          site: settings.site,
+          collectDomain: settings.collectDomain,
+          ...(isObject(settings.options) ? settings.options : {}),
+        });
+      }
+    };
 
-    const pa = resolvePa(env);
-    if (pa && isDefined(settings.site) && isDefined(settings.collectDomain)) {
-      pa.setConfigurations({
-        site: settings.site,
-        collectDomain: settings.collectDomain,
-        ...(isObject(settings.options) ? settings.options : {}),
-      });
+    // When we inject the SDK it loads asynchronously, so `window.pa` is not
+    // available in the same tick. Defer configuration until `onload` fires.
+    if (config.loadScript) {
+      addScript(SCRIPT_SRC, configure);
+    } else {
+      configure();
     }
 
     return config;
@@ -46,10 +54,11 @@ function resolvePa(env: Env): PianoAnalytics | undefined {
   );
 }
 
-function addScript(src = SCRIPT_SRC) {
+function addScript(src = SCRIPT_SRC, onReady?: () => void) {
   if (typeof document === 'undefined') return;
   const script = document.createElement('script');
   script.src = src;
+  if (onReady) script.onload = () => onReady();
   document.head.appendChild(script);
 }
 


### PR DESCRIPTION
## Problem

With the Piano destination configured as `loadScript: true`, I found that the `site` and `collectDomain` settings never reach the Piano Analytics SDK. Collection hits go to the default/unconfigured endpoint, with no error or warning, so it fails silently.

## Root cause

In `packages/web/destinations/piano/src/index.ts`, `init` injects the SDK `<script>` asynchronously and then, in the same synchronous tick, reads `window.pa` (via `resolvePa(env)`) and calls `pa.setConfigurations(...)`:

```ts
if (config.loadScript) addScript();       // appends <script>, loads async
const pa = resolvePa(env);                // window.pa still undefined here
if (pa && ...) pa.setConfigurations(...);  // guard short-circuits, skipped
```

On a cold page the script has not loaded yet, so `window.pa` is `undefined`, the guard short-circuits, and `setConfigurations` never runs. Events are still delivered later (each `push` re-resolves `window.pa` lazily), but without the configured `site`/`collectDomain`.

## Fix

I extracted the configuration into a `configure()` closure and let `addScript` accept an `onReady` callback wired to `script.onload`:

- `loadScript: true` runs `configure()` after the SDK's `onload` fires.
- `loadScript: false` runs `configure()` synchronously against an already-present `window.pa` (unchanged behavior).

Minimal change, one source file. I also added a test that asserts `setConfigurations` is not called until `script.onload` fires (it fails against the previous code and passes with the fix).

## Verification

- `typecheck` passes
- `lint` passes
- `jest` passes (8/8, including the new regression test)

Fixes #681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When dynamic SDK loading is enabled, Piano `site` and `collectDomain` settings are now applied only after the SDK script successfully loads.
  * If the SDK script fails to load (for example, blocked or unavailable), configurations are not applied and a warning is logged instead of sending unconfigured events.

* **Tests**
  * Added Jest coverage to verify configuration timing (post-`onload`) and correct warning behavior on script load failure (`onerror`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->