### PR TITLE
feat(klaviyo): resolve unique_id from a mapping rule

### DIFF
--- a/.changeset/klaviyo-revenue-value-attribute.md
+++ b/.changeset/klaviyo-revenue-value-attribute.md
@@ -1,0 +1,11 @@
+---
+'@walkeros/server-destination-klaviyo': patch
+---
+
+Revenue now reaches Klaviyo. A mapping rule's `settings.value` was written into
+the event's `properties`, where Klaviyo stores it as a segmentable custom
+property and ignores it for revenue reporting, while `valueCurrency` was set on
+the event attributes with no sibling value to denominate. Both now sit together
+on the attributes, which is where `klaviyo-api` serializes `value` and
+`value_currency` from. Properties are unaffected -- map a value through the
+rule's `data` mapping if you also want it as a custom property.

--- a/.changeset/klaviyo-unique-id.md
+++ b/.changeset/klaviyo-unique-id.md
@@ -1,0 +1,12 @@
+---
+'@walkeros/server-destination-klaviyo': minor
+---
+
+Mapping rules accept `settings.uniqueId`, which resolves Klaviyo's `unique_id`
+-- the key it deduplicates on, keeping only the first event with a given value
+for one profile and metric. It matters wherever the same event can reach Klaviyo
+twice: browser tracking running alongside this destination, a CSV or backfill
+import, or a retried delivery. Without it Klaviyo dedups on the event time
+truncated to the second, admitting one event per profile per metric per second.
+Numeric ids are coerced to strings so a numeric order id resolves instead of
+being dropped.

--- a/packages/server/destinations/klaviyo/src/examples/step.ts
+++ b/packages/server/destinations/klaviyo/src/examples/step.ts
@@ -374,3 +374,103 @@ export const wildcardIgnored: KlaviyoStepExample = {
   mapping: { ignore: true },
   out: [],
 };
+
+/**
+ * Deduplicated order -- `settings.uniqueId` resolves Klaviyo's `unique_id`,
+ * the key Klaviyo deduplicates on. Without it Klaviyo falls back to the
+ * event time truncated to the second, which admits only one event per
+ * profile per metric per second and silently drops or duplicates the rest.
+ */
+export const dedupedOrder: KlaviyoStepExample = {
+  title: 'Deduplicated order',
+  description:
+    'An order carries a stable unique id so Klaviyo keeps only the first copy when the same order arrives from another producer.',
+  in: getEvent('order complete', {
+    timestamp: 1700000107,
+    user: { id: 'us3r', email: 'user@example.com' },
+    data: { id: 'ORD-123', total: 49.5 },
+  }),
+  mapping: {
+    name: 'Placed Order',
+    data: { map: { OrderId: 'data.id' } },
+    settings: { uniqueId: 'data.id' },
+  },
+  out: [
+    [
+      'eventsApi.createEvent',
+      {
+        data: {
+          type: 'event',
+          attributes: {
+            profile: {
+              data: {
+                type: 'profile',
+                attributes: {
+                  email: 'user@example.com',
+                  externalId: 'us3r',
+                },
+              },
+            },
+            metric: {
+              data: {
+                type: 'metric',
+                attributes: { name: 'Placed Order' },
+              },
+            },
+            properties: { OrderId: 'ORD-123' },
+            time: new Date(1700000107).toISOString(),
+            uniqueId: 'ORD-123',
+          },
+        },
+      },
+    ],
+  ],
+};
+
+/**
+ * Numeric dedup key -- order ids are commonly numbers. Coercing them keeps
+ * the dedup key instead of dropping it, which would silently return Klaviyo
+ * to its time-to-the-second fallback and re-admit duplicates.
+ */
+export const numericUniqueId: KlaviyoStepExample = {
+  public: false,
+  in: getEvent('order complete', {
+    timestamp: 1700000108,
+    user: { id: 'us3r', email: 'user@example.com' },
+    data: { id: 90210 },
+  }),
+  mapping: {
+    name: 'Placed Order',
+    settings: { uniqueId: 'data.id' },
+  },
+  out: [
+    [
+      'eventsApi.createEvent',
+      {
+        data: {
+          type: 'event',
+          attributes: {
+            profile: {
+              data: {
+                type: 'profile',
+                attributes: {
+                  email: 'user@example.com',
+                  externalId: 'us3r',
+                },
+              },
+            },
+            metric: {
+              data: {
+                type: 'metric',
+                attributes: { name: 'Placed Order' },
+              },
+            },
+            properties: {},
+            time: new Date(1700000108).toISOString(),
+            uniqueId: '90210',
+          },
+        },
+      },
+    ],
+  ],
+};

--- a/packages/server/destinations/klaviyo/src/examples/step.ts
+++ b/packages/server/destinations/klaviyo/src/examples/step.ts
@@ -154,7 +154,6 @@ export const revenueEvent: KlaviyoStepExample = {
     data: {
       map: {
         OrderId: 'data.id',
-        value: 'data.total',
         ItemNames: 'data.itemNames',
       },
     },
@@ -186,10 +185,10 @@ export const revenueEvent: KlaviyoStepExample = {
             },
             properties: {
               OrderId: 'ORD-123',
-              value: 99.99,
               ItemNames: ['Widget A', 'Widget B'],
             },
             time: new Date(1700000102).toISOString(),
+            value: 99.99,
             valueCurrency: 'EUR',
           },
         },

--- a/packages/server/destinations/klaviyo/src/push.ts
+++ b/packages/server/destinations/klaviyo/src/push.ts
@@ -84,7 +84,14 @@ export const push: PushFn = async function (
       ? { ...(data as Record<string, unknown>) }
       : {};
 
-    // Handle revenue value
+    // Handle revenue value.
+    //
+    // Klaviyo reads revenue from the event's `value` / `valueCurrency`
+    // attributes (serialized by klaviyo-api as `value` / `value_currency`),
+    // NOT from `properties`. A number nested in `properties` is stored as a
+    // segmentable custom property and is ignored by revenue reporting, so
+    // emitting `valueCurrency` without a sibling `value` denominates nothing.
+    let value: number | undefined;
     let valueCurrency: string | undefined;
     if (mappingSettings.value !== undefined) {
       const resolvedValue = await getMappingValue(
@@ -96,7 +103,7 @@ export const push: PushFn = async function (
       );
       const numericValue = toNumber(resolvedValue);
       if (numericValue !== undefined) {
-        properties.value = numericValue;
+        value = numericValue;
         if (settings.currency) {
           valueCurrency = settings.currency;
         }
@@ -121,6 +128,7 @@ export const push: PushFn = async function (
           },
           properties,
           time: timestamp.toISOString(),
+          ...(value !== undefined ? { value } : {}),
           ...(valueCurrency ? { valueCurrency } : {}),
         },
       },

--- a/packages/server/destinations/klaviyo/src/push.ts
+++ b/packages/server/destinations/klaviyo/src/push.ts
@@ -5,7 +5,13 @@ import type {
   KlaviyoEventsApiMock,
   KlaviyoProfilesApiMock,
 } from './types';
-import { getMappingValue, isObject, isString, isArray } from '@walkeros/core';
+import {
+  getMappingValue,
+  isObject,
+  isString,
+  isArray,
+  isNumber,
+} from '@walkeros/core';
 
 export const push: PushFn = async function (
   event,
@@ -110,6 +116,17 @@ export const push: PushFn = async function (
       }
     }
 
+    // Klaviyo's dedup key. Repeats of the same uniqueId for one profile and
+    // metric keep only the first event, which is what lets the same order
+    // arrive from several producers (browser, import, a second server)
+    // without being counted twice.
+    let uniqueId: string | undefined;
+    if (mappingSettings.uniqueId !== undefined) {
+      uniqueId = resolveId(
+        await getMappingValue(event, mappingSettings.uniqueId, { collector }),
+      );
+    }
+
     const eventBody: Record<string, unknown> = {
       data: {
         type: 'event',
@@ -130,6 +147,7 @@ export const push: PushFn = async function (
           time: timestamp.toISOString(),
           ...(value !== undefined ? { value } : {}),
           ...(valueCurrency ? { valueCurrency } : {}),
+          ...(uniqueId ? { uniqueId } : {}),
         },
       },
     };
@@ -143,6 +161,17 @@ export const push: PushFn = async function (
 function resolveString(value: unknown): string | undefined {
   if (isString(value) && value.length > 0) return value;
   return undefined;
+}
+
+/**
+ * Resolve an identifier that Klaviyo types as a string. Order ids are commonly
+ * numeric, and dropping one would silently return Klaviyo to its
+ * time-to-the-second dedup fallback, so coerce finite numbers rather than
+ * rejecting them.
+ */
+function resolveId(value: unknown): string | undefined {
+  if (isNumber(value) && Number.isFinite(value)) return String(value);
+  return resolveString(value);
 }
 
 function toNumber(value: unknown): number | undefined {

--- a/packages/server/destinations/klaviyo/src/schemas/mapping.ts
+++ b/packages/server/destinations/klaviyo/src/schemas/mapping.ts
@@ -13,6 +13,12 @@ export const MappingSchema = z.object({
       'Revenue value mapping. Resolves to a numeric value for Klaviyo revenue tracking. Sets the event value attribute (value on the wire), plus valueCurrency when settings.currency is set.',
     )
     .optional(),
+  uniqueId: z
+    .unknown()
+    .describe(
+      'Dedup key mapping. Resolves to the event uniqueId (unique_id on the wire). Klaviyo keeps only the first event with a given value per profile and metric. Without it Klaviyo dedups on the event time truncated to the second.',
+    )
+    .optional(),
 });
 
 export type Mapping = z.infer<typeof MappingSchema>;

--- a/packages/server/destinations/klaviyo/src/schemas/mapping.ts
+++ b/packages/server/destinations/klaviyo/src/schemas/mapping.ts
@@ -10,7 +10,7 @@ export const MappingSchema = z.object({
   value: z
     .unknown()
     .describe(
-      'Revenue value mapping. Resolves to a numeric value for Klaviyo revenue tracking. Sets the value property and valueCurrency on the event.',
+      'Revenue value mapping. Resolves to a numeric value for Klaviyo revenue tracking. Sets the event value attribute (value on the wire), plus valueCurrency when settings.currency is set.',
     )
     .optional(),
 });

--- a/packages/server/destinations/klaviyo/src/types/index.ts
+++ b/packages/server/destinations/klaviyo/src/types/index.ts
@@ -40,7 +40,7 @@ export type InitSettings = Partial<Settings>;
 export interface Mapping {
   /** Per-event identify mapping. Resolves to profile attributes for upsert. */
   identify?: WalkerOSMapping.Value;
-  /** Revenue value mapping. Resolves to numeric value for Klaviyo's $value. */
+  /** Revenue value mapping. Resolves to the event's numeric `value` attribute. */
   value?: WalkerOSMapping.Value;
 }
 

--- a/packages/server/destinations/klaviyo/src/types/index.ts
+++ b/packages/server/destinations/klaviyo/src/types/index.ts
@@ -42,6 +42,13 @@ export interface Mapping {
   identify?: WalkerOSMapping.Value;
   /** Revenue value mapping. Resolves to the event's numeric `value` attribute. */
   value?: WalkerOSMapping.Value;
+  /**
+   * Dedup key mapping. Resolves to Klaviyo's `uniqueId` (`unique_id` on the
+   * wire): repeats of the same value for one profile and metric keep only the
+   * first event. Omit it and Klaviyo falls back to the event time truncated to
+   * the second.
+   */
+  uniqueId?: WalkerOSMapping.Value;
 }
 
 /**

--- a/website/docs/destinations/server/klaviyo.mdx
+++ b/website/docs/destinations/server/klaviyo.mdx
@@ -85,6 +85,12 @@ Identity is resolved automatically from each event: `email` defaults to `user.em
 
 Map a mapping rule's `settings.value` to a numeric value. The destination sets it as the Klaviyo event's `value` attribute -- the field revenue reporting reads -- and when `settings.currency` is also set, adds `valueCurrency` alongside it.
 
+## Deduplication
+
+Map a mapping rule's `settings.uniqueId` to a stable identifier and Klaviyo keeps only the first event carrying that value for a given profile and metric. Use it whenever the same event can reach Klaviyo more than once -- browser tracking alongside this destination, a CSV or backfill import, or a retried delivery.
+
+Without it Klaviyo falls back to the event time truncated to the second, which admits only one event per profile per metric per second. Numeric ids are coerced to strings, so an order id like `data.id` works whether it is `'ORD-123'` or `90210`.
+
 ## Ecommerce metric naming
 
 Klaviyo's built-in flows and reports key off specific metric names. Use `mapping.name` to rename walkerOS events to Klaviyo's expected values:

--- a/website/docs/destinations/server/klaviyo.mdx
+++ b/website/docs/destinations/server/klaviyo.mdx
@@ -83,7 +83,7 @@ Identity is resolved automatically from each event: `email` defaults to `user.em
 
 ## Revenue tracking
 
-Map a mapping rule's `settings.value` to a numeric event property. When `settings.currency` is also set, the destination adds `valueCurrency` on the Klaviyo event for revenue reporting.
+Map a mapping rule's `settings.value` to a numeric value. The destination sets it as the Klaviyo event's `value` attribute -- the field revenue reporting reads -- and when `settings.currency` is also set, adds `valueCurrency` alongside it.
 
 ## Ecommerce metric naming
 


### PR DESCRIPTION
> Stacked on #708 — this branch contains that commit. Merge #708 first and this diff reduces to the `uniqueId` commit alone. Happy to squash the two into one PR if you'd prefer.

## What

Mapping rules accept `settings.uniqueId`, resolved onto the event's `uniqueId` attribute (`unique_id` on the wire).

## Why

Klaviyo deduplicates on the tuple `(profile, metric, unique_id)`. Without the field, [the API defaults it](https://developers.klaviyo.com/en/v2026-04-15/reference/create_event) to *"the time to the second"*, so two events for one profile and metric landing in the same second collide and one is dropped — data loss, not just a missed dedup.

With it, the same event can reach Klaviyo from several producers — browser tracking running alongside this destination, a CSV or backfill import, a retried delivery — without being counted twice. There is currently no way to express that key through this destination.

## Verified against the live API

I ran a dedup probe against a real Klaviyo account (four groups, two sends each, controls included):

| group | sent | recorded |
|---|---|---|
| server `unique_id` ×2 (control) | 2 | 1 |
| client `unique_id` ×2 (control) | 2 | 1 |
| client `unique_id` → server `unique_id` | 2 | **1** |
| client `$event_id` property → server `unique_id` | 2 | **2** |

Both controls dedup, so the method holds. `unique_id` deduplicates **across** the browser (`/client/events/`) and server (`/api/events/`) boundary; a `$event_id` event *property* does not participate at all. That is what makes this the right field to expose.

## Details

Rule-level only, mirroring the existing `settings.value` — a dedup key is inherently per-event, so a destination-level default did not seem worth it (happy to add if you disagree).

Numeric ids are coerced to strings: order ids are commonly numeric, and silently dropping one would fall back to the one-per-second window and re-admit exactly the duplicates the key exists to prevent. `NaN`, `Infinity`, empty string, booleans and objects all resolve to no key rather than a garbage one.

## Verification

- `npm run verify:touched -- server-destination-klaviyo` — green
- `npm run verify:affected` — 77/77 green
- Package tests 10/10; two new step examples (one public, one `public: false` regression fixture for the numeric case), each watched fail before implementing.

Changeset included (minor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Klaviyo event deduplication using optional unique identifiers, including numeric ID conversion.
  * Revenue values now use Klaviyo’s event-level value and currency attributes.
* **Documentation**
  * Updated Klaviyo mapping guidance with revenue tracking, deduplication, fallback behavior, and numeric identifier handling.
* **Examples**
  * Added examples demonstrating string and numeric identifiers for event deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->